### PR TITLE
Genotype likelihoods

### DIFF
--- a/locator/cli.py
+++ b/locator/cli.py
@@ -19,8 +19,8 @@ def parse_args():
         help="tab-delimited matrix of genotype dosage with first column "
         "named 'sampleID'. Accepts both hard-call dosage (integers 0/1/2) "
         "and continuous expected dosage from genotype-likelihood pipelines "
-        "(floats in [0, 2]). See docs/genotype_likelihoods.md for the GL "
-        "workflow. E.g., "
+        "(floats in [0, 2]). For the GL preprocessing workflow, see "
+        "`scripts/gl_to_locator.py --help`. E.g., "
         "sampleID\\tsite1\\tsite2\\t... "
         "msp1\\t0\\t1\\t... "
         "msp2\\t2\\t0\\t...",

--- a/locator/cli.py
+++ b/locator/cli.py
@@ -16,13 +16,14 @@ def parse_args():
     parser.add_argument("--zarr", help="zarr file of SNPs for all samples.")
     parser.add_argument(
         "--matrix",
-        help="tab-delimited matrix of minor allele counts with \
-            first column named 'sampleID'.\
-                                     E.g., \
-                                     \
-                                     sampleID\tsite1\tsite2\t...\n \
-                                     msp1\t0\t1\t...\n \
-                                     msp2\t2\t0\t...\n ",
+        help="tab-delimited matrix of genotype dosage with first column "
+        "named 'sampleID'. Accepts both hard-call dosage (integers 0/1/2) "
+        "and continuous expected dosage from genotype-likelihood pipelines "
+        "(floats in [0, 2]). See docs/genotype_likelihoods.md for the GL "
+        "workflow. E.g., "
+        "sampleID\\tsite1\\tsite2\\t... "
+        "msp1\\t0\\t1\\t... "
+        "msp2\\t2\\t0\\t...",
     )
     parser.add_argument(
         "--sample_data",

--- a/locator/data/__init__.py
+++ b/locator/data/__init__.py
@@ -6,6 +6,7 @@ from .filters import (
     filter_snps,
     filter_snps_legacy,
     impute_missing,
+    is_dosage_matrix,
     normalize_locs,
     normalize_locs_params,
 )
@@ -19,6 +20,7 @@ __all__ = [
     "filter_snps",
     "filter_snps_legacy",
     "impute_missing",
+    "is_dosage_matrix",
     "normalize_locs",
     "normalize_locs_params",
     "IndexSet",

--- a/locator/data/__init__.py
+++ b/locator/data/__init__.py
@@ -3,6 +3,7 @@
 from .filters import (
     FilterStats,
     NormalizationParams,
+    filter_dosage_matrix,
     filter_snps,
     filter_snps_legacy,
     impute_missing,
@@ -17,6 +18,7 @@ from .windows import generate_genomic_windows
 __all__ = [
     "FilterStats",
     "NormalizationParams",
+    "filter_dosage_matrix",
     "filter_snps",
     "filter_snps_legacy",
     "impute_missing",

--- a/locator/data/filters.py
+++ b/locator/data/filters.py
@@ -130,6 +130,21 @@ def impute_missing(genotypes) -> np.ndarray:
     return ac
 
 
+def is_dosage_matrix(genotypes) -> bool:
+    """Detect a continuous-dosage matrix vs an allel.GenotypeArray.
+
+    GL-derived inputs flow through `_load_from_matrix` as 2D float ndarrays
+    of shape (n_sites, n_samples); hard-call inputs are allel.GenotypeArray
+    of shape (n_sites, n_samples, ploidy). Downstream filtering, training,
+    and prediction code dispatches on this distinction.
+    """
+    return (
+        isinstance(genotypes, np.ndarray)
+        and genotypes.ndim == 2
+        and np.issubdtype(genotypes.dtype, np.floating)
+    )
+
+
 def filter_snps(
     genotypes,
     min_mac: int = 1,

--- a/locator/data/filters.py
+++ b/locator/data/filters.py
@@ -145,6 +145,48 @@ def is_dosage_matrix(genotypes) -> bool:
     )
 
 
+def filter_dosage_matrix(
+    dosage: np.ndarray,
+    min_mac: int = 2,
+    max_snps: Optional[int] = None,
+) -> np.ndarray:
+    """MAC and max_snps filters for continuous dosage input.
+
+    Mean dosage at a site is in [0, 2]; minor-allele frequency is
+    ``min(mean, 2 - mean) / 2``, and the implied minor-allele count is
+    ``MAF * 2 * n_samples``. Sites below ``min_mac`` are dropped.
+
+    Imputation must happen upstream: NaN values raise ``ValueError`` rather
+    than silently dropping every site (a NaN mean propagates through the MAC
+    comparison and would otherwise mask all sites out).
+
+    Args:
+        dosage: ``(n_sites, n_samples)`` float ndarray with values in [0, 2].
+        min_mac: Minimum implied minor-allele count for a site to be kept.
+        max_snps: Optional cap on retained sites (random subset).
+
+    Returns
+    -------
+        Contiguous float32 ndarray of filtered sites.
+    """
+    if np.isnan(dosage).any():
+        raise ValueError(
+            "dosage matrix contains NaN values; impute upstream "
+            "(e.g. via gl_to_locator.py site-mean fill) before passing "
+            "to ReLocator."
+        )
+    n_sites, n_samples = dosage.shape
+    mean_dosage = dosage.mean(axis=1)
+    minor_freq = np.minimum(mean_dosage, 2.0 - mean_dosage) / 2.0
+    implied_mac = minor_freq * 2.0 * n_samples
+    mask = implied_mac >= float(min_mac)
+    dosage = dosage[mask, :]
+    if max_snps is not None and max_snps < dosage.shape[0]:
+        idx = np.random.choice(dosage.shape[0], max_snps, replace=False)
+        dosage = dosage[np.sort(idx), :]
+    return np.ascontiguousarray(dosage, dtype=np.float32)
+
+
 def filter_snps(
     genotypes,
     min_mac: int = 1,

--- a/locator/loaders.py
+++ b/locator/loaders.py
@@ -122,21 +122,42 @@ class DataLoaderMixin:
     def _load_from_matrix(self, matrix_path):
         """Load genotypes from matrix file.
 
+        Two input dialects are accepted, distinguished by dtype:
+
+        - **Hard-call dosage** (integer 0/1/2): routed through
+          ``_counts_to_genotype_array`` and returned as an ``allel.GenotypeArray``
+          of shape ``(n_sites, n_samples, 2)``. Original behavior.
+        - **Continuous dosage** (float column with values in [0, 2], e.g.
+          expected dosage from GL-based callers): the matrix is returned
+          directly as a 2D ``np.ndarray`` of shape ``(n_sites, n_samples)``
+          with no allel.GenotypeArray round trip. Downstream
+          ``_filter_genotypes`` in training.py recognizes this branch and
+          applies MAC/max_snps filters on the continuous values directly,
+          skipping biallelic checks (which are not meaningful for continuous
+          dosage). NaN values are silently dropped at the MAC filter —
+          callers should impute upstream (gl_to_locator.py site-mean fill
+          handles this for ANGSD beagle inputs).
+
         Args:
             matrix_path: Path to tab-delimited matrix file containing genotype data.
                 File should have a header row with 'sampleID' as first column,
-                followed by variant columns. Each row contains genotype counts (0,1,2)
-                for one sample.
+                followed by variant columns.
 
         Returns
         -------
-            tuple: (genotypes, samples) where:
-                - genotypes is an allel.GenotypeArray containing genetic data
-                - samples is a numpy array of sample IDs
+            tuple: (genotypes, samples)
         """
         gmat = pd.read_csv(matrix_path, sep="\t")
         samples = np.array(gmat["sampleID"])
         gmat = gmat.drop(labels="sampleID", axis=1)
+
+        if np.issubdtype(gmat.values.dtype, np.floating):
+            # Continuous dosage path. Shape becomes (n_sites, n_samples) to
+            # match the downstream ``ac`` representation produced by
+            # ``filter_snps`` for the integer path.
+            dosage = np.asarray(gmat.values, dtype=np.float32).T
+            return dosage, samples
+
         if not np.all(np.isin(gmat, [0, 1, 2])):
             raise ValueError("Genotype values must be 0, 1, or 2")
         gmat = np.array(gmat, dtype="int8")

--- a/locator/loaders.py
+++ b/locator/loaders.py
@@ -156,6 +156,12 @@ class DataLoaderMixin:
             # match the downstream ``ac`` representation produced by
             # ``filter_snps`` for the integer path.
             dosage = np.asarray(gmat.values, dtype=np.float32).T
+            if not ((dosage >= 0.0) & (dosage <= 2.0)).all():
+                raise ValueError(
+                    "Continuous-dosage matrix has values outside [0, 2]; "
+                    "expected expected-dosage encoding (e.g. from "
+                    "scripts/gl_to_locator.py)."
+                )
             return dosage, samples
 
         if not np.all(np.isin(gmat, [0, 1, 2])):

--- a/locator/prediction.py
+++ b/locator/prediction.py
@@ -7,7 +7,7 @@ import h5py
 import numpy as np
 import pandas as pd
 
-from .data import is_dosage_matrix
+from .data import filter_dosage_matrix, is_dosage_matrix
 
 
 class PredictionMixin:
@@ -127,7 +127,11 @@ class PredictionMixin:
             if hasattr(self, "filtered_genotypes"):
                 filtered_genotypes = self.filtered_genotypes
             elif is_dosage_matrix(genotypes):
-                filtered_genotypes = self._filter_dosage_matrix(genotypes)
+                filtered_genotypes = filter_dosage_matrix(
+                    genotypes,
+                    min_mac=self.config.get("min_mac", 2),
+                    max_snps=self.config.get("max_SNPs"),
+                )
             else:
                 from .data import filter_snps_legacy as filter_snps
                 filtered_genotypes = filter_snps(
@@ -388,7 +392,11 @@ class PredictionMixin:
             impute = self.config.get("impute_missing", False)
 
         if is_dosage_matrix(genotypes):
-            filtered_genotypes = self._filter_dosage_matrix(genotypes)
+            filtered_genotypes = filter_dosage_matrix(
+                genotypes,
+                min_mac=min_mac,
+                max_snps=max_snps,
+            )
         else:
             from .data import filter_snps_legacy as filter_snps
             filtered_genotypes = filter_snps(

--- a/locator/prediction.py
+++ b/locator/prediction.py
@@ -7,6 +7,8 @@ import h5py
 import numpy as np
 import pandas as pd
 
+from .data import is_dosage_matrix
+
 
 class PredictionMixin:
     """Mixin class providing prediction functionality for Locator."""
@@ -123,10 +125,11 @@ class PredictionMixin:
 
             # Filter genotypes using the same parameters as training
             if hasattr(self, "filtered_genotypes"):
-                # Use stored filtered genotypes if available
                 filtered_genotypes = self.filtered_genotypes
+            elif is_dosage_matrix(genotypes):
+                filtered_genotypes = self._filter_dosage_matrix(genotypes)
             else:
-                # Apply filtering to the provided genotypes
+                from .data import filter_snps_legacy as filter_snps
                 filtered_genotypes = filter_snps(
                     genotypes,
                     min_mac=self.config.get("min_mac", 2),
@@ -375,25 +378,21 @@ class PredictionMixin:
                 else np.array([])
             )
 
-        # Apply preprocessing using saved parameters
         if metadata and "preprocessing" in metadata:
-            from .data import filter_snps_legacy as filter_snps
-
-            filtered_genotypes = filter_snps(
-                genotypes,
-                min_mac=metadata["preprocessing"]["min_mac"],
-                max_snps=metadata["preprocessing"]["max_SNPs"],
-                impute=metadata["preprocessing"]["impute_missing"],
-            )
+            min_mac = metadata["preprocessing"]["min_mac"]
+            max_snps = metadata["preprocessing"]["max_SNPs"]
+            impute = metadata["preprocessing"]["impute_missing"]
         else:
-            # Use current config if no metadata
-            from .data import filter_snps_legacy as filter_snps
+            min_mac = self.config.get("min_mac", 2)
+            max_snps = self.config.get("max_SNPs")
+            impute = self.config.get("impute_missing", False)
 
+        if is_dosage_matrix(genotypes):
+            filtered_genotypes = self._filter_dosage_matrix(genotypes)
+        else:
+            from .data import filter_snps_legacy as filter_snps
             filtered_genotypes = filter_snps(
-                genotypes,
-                min_mac=self.config.get("min_mac", 2),
-                max_snps=self.config.get("max_SNPs"),
-                impute=self.config.get("impute_missing", False),
+                genotypes, min_mac=min_mac, max_snps=max_snps, impute=impute,
             )
 
         # Prepare prediction genotypes

--- a/locator/prediction.py
+++ b/locator/prediction.py
@@ -134,6 +134,7 @@ class PredictionMixin:
                 )
             else:
                 from .data import filter_snps_legacy as filter_snps
+
                 filtered_genotypes = filter_snps(
                     genotypes,
                     min_mac=self.config.get("min_mac", 2),
@@ -399,8 +400,12 @@ class PredictionMixin:
             )
         else:
             from .data import filter_snps_legacy as filter_snps
+
             filtered_genotypes = filter_snps(
-                genotypes, min_mac=min_mac, max_snps=max_snps, impute=impute,
+                genotypes,
+                min_mac=min_mac,
+                max_snps=max_snps,
+                impute=impute,
             )
 
         # Prepare prediction genotypes

--- a/locator/training.py
+++ b/locator/training.py
@@ -9,7 +9,7 @@ import numpy as np
 import pandas as pd
 from tensorflow import keras
 
-from .data import IndexSet, make_tf_dataset, normalize_locs
+from .data import IndexSet, is_dosage_matrix, make_tf_dataset, normalize_locs
 from .data import filter_snps_legacy as filter_snps
 from .gpu_optimizer import GPUOptimizer
 from .models import create_network, loss_with_range_penalty, rasterize_species_range
@@ -760,26 +760,59 @@ class TrainingMixin:
     def _filter_genotypes(self, genotypes, filtered_genotypes=None):
         """Filter SNPs and store result as self.filtered_genotypes.
 
+        Two genotype input dialects are accepted:
+
+        - ``allel.GenotypeArray`` (n_sites, n_samples, ploidy): the original
+          path; biallelic check + MAC + max_snps + optional imputation via
+          ``filter_snps``.
+        - 2D float ``np.ndarray`` (n_sites, n_samples): continuous dosage
+          (e.g., GL-derived expected dosage). Biallelic check is skipped (not
+          meaningful for continuous values); MAC and max_snps filters are
+          applied directly on the dosage matrix.
+
         Args:
-            genotypes: Raw GenotypeArray or window slice
+            genotypes: Raw GenotypeArray, 2D float ndarray, or window slice
             filtered_genotypes: Pre-filtered allele counts (skips filtering)
 
         Returns
         -------
-            np.ndarray: Filtered allele count array
+            np.ndarray: Filtered allele count / dosage array, shape (n_sites, n_samples)
         """
         if filtered_genotypes is not None:
             self.filtered_genotypes = filtered_genotypes
         elif genotypes is not None:
-            self.filtered_genotypes = filter_snps(
-                genotypes,
-                min_mac=self.config.get("min_mac", 2),
-                max_snps=self.config.get("max_SNPs"),
-                impute=self.config.get("impute_missing", False),
-            )
+            if is_dosage_matrix(genotypes):
+                self.filtered_genotypes = self._filter_dosage_matrix(genotypes)
+            else:
+                self.filtered_genotypes = filter_snps(
+                    genotypes,
+                    min_mac=self.config.get("min_mac", 2),
+                    max_snps=self.config.get("max_SNPs"),
+                    impute=self.config.get("impute_missing", False),
+                )
         else:
             raise ValueError("Either genotypes or filtered_genotypes must be provided")
         return self.filtered_genotypes
+
+    def _filter_dosage_matrix(self, dosage):
+        """MAC and max_snps filters for continuous dosage input.
+
+        Mean dosage at a site is in [0, 2]; minor-allele frequency is
+        ``min(mean, 2 - mean) / 2``, and the implied minor-allele count is
+        ``MAF * 2 * n_samples``. Sites below ``min_mac`` are dropped. Imputation
+        is assumed to have happened upstream (gl_to_locator.py site-mean fill).
+        """
+        n_sites, n_samples = dosage.shape
+        mean_dosage = dosage.mean(axis=1)
+        minor_freq = np.minimum(mean_dosage, 2.0 - mean_dosage) / 2.0
+        implied_mac = minor_freq * 2.0 * n_samples
+        mask = implied_mac >= float(self.config.get("min_mac", 2))
+        dosage = dosage[mask, :]
+        max_snps = self.config.get("max_SNPs")
+        if max_snps is not None and max_snps < dosage.shape[0]:
+            idx = np.random.choice(dosage.shape[0], max_snps, replace=False)
+            dosage = dosage[np.sort(idx), :]
+        return np.ascontiguousarray(dosage, dtype=np.float32)
 
     def _store_holdout_state(self, holdout_idx, normalized_locs):
         """Store holdout data for use by predict_holdout().

--- a/locator/training.py
+++ b/locator/training.py
@@ -9,7 +9,13 @@ import numpy as np
 import pandas as pd
 from tensorflow import keras
 
-from .data import IndexSet, is_dosage_matrix, make_tf_dataset, normalize_locs
+from .data import (
+    IndexSet,
+    filter_dosage_matrix,
+    is_dosage_matrix,
+    make_tf_dataset,
+    normalize_locs,
+)
 from .data import filter_snps_legacy as filter_snps
 from .gpu_optimizer import GPUOptimizer
 from .models import create_network, loss_with_range_penalty, rasterize_species_range
@@ -782,7 +788,11 @@ class TrainingMixin:
             self.filtered_genotypes = filtered_genotypes
         elif genotypes is not None:
             if is_dosage_matrix(genotypes):
-                self.filtered_genotypes = self._filter_dosage_matrix(genotypes)
+                self.filtered_genotypes = filter_dosage_matrix(
+                    genotypes,
+                    min_mac=self.config.get("min_mac", 2),
+                    max_snps=self.config.get("max_SNPs"),
+                )
             else:
                 self.filtered_genotypes = filter_snps(
                     genotypes,
@@ -793,26 +803,6 @@ class TrainingMixin:
         else:
             raise ValueError("Either genotypes or filtered_genotypes must be provided")
         return self.filtered_genotypes
-
-    def _filter_dosage_matrix(self, dosage):
-        """MAC and max_snps filters for continuous dosage input.
-
-        Mean dosage at a site is in [0, 2]; minor-allele frequency is
-        ``min(mean, 2 - mean) / 2``, and the implied minor-allele count is
-        ``MAF * 2 * n_samples``. Sites below ``min_mac`` are dropped. Imputation
-        is assumed to have happened upstream (gl_to_locator.py site-mean fill).
-        """
-        n_sites, n_samples = dosage.shape
-        mean_dosage = dosage.mean(axis=1)
-        minor_freq = np.minimum(mean_dosage, 2.0 - mean_dosage) / 2.0
-        implied_mac = minor_freq * 2.0 * n_samples
-        mask = implied_mac >= float(self.config.get("min_mac", 2))
-        dosage = dosage[mask, :]
-        max_snps = self.config.get("max_SNPs")
-        if max_snps is not None and max_snps < dosage.shape[0]:
-            idx = np.random.choice(dosage.shape[0], max_snps, replace=False)
-            dosage = dosage[np.sort(idx), :]
-        return np.ascontiguousarray(dosage, dtype=np.float32)
 
     def _store_holdout_state(self, holdout_idx, normalized_locs):
         """Store holdout data for use by predict_holdout().

--- a/scripts/gl_to_locator.py
+++ b/scripts/gl_to_locator.py
@@ -146,9 +146,7 @@ def load_beagle(beagle_path):
     try:
         gl_flat = np.array(rows, dtype=np.float32)
     except ValueError as e:
-        raise ValueError(
-            f"Failed to parse beagle GL values as float32. Error: {e}"
-        )
+        raise ValueError(f"Failed to parse beagle GL values as float32. Error: {e}")
 
     print(f"  Loaded {len(markers)} sites", flush=True)
     return markers, gl_flat
@@ -242,15 +240,13 @@ def cross_check_sample_ids(derived_ids, sample_data_path):
     if in_derived_not_sd:
         print(
             f"WARNING: {len(in_derived_not_sd)} sample IDs derived from BAM list "
-            f"are NOT in sample_data.txt:\n  "
-            + "\n  ".join(sorted(in_derived_not_sd)),
+            f"are NOT in sample_data.txt:\n  " + "\n  ".join(sorted(in_derived_not_sd)),
             file=sys.stderr,
         )
     if in_sd_not_derived:
         print(
             f"WARNING: {len(in_sd_not_derived)} sample IDs in sample_data.txt "
-            f"are NOT in BAM list:\n  "
-            + "\n  ".join(sorted(in_sd_not_derived)),
+            f"are NOT in BAM list:\n  " + "\n  ".join(sorted(in_sd_not_derived)),
             file=sys.stderr,
         )
     if not in_derived_not_sd and not in_sd_not_derived:

--- a/scripts/gl_to_locator.py
+++ b/scripts/gl_to_locator.py
@@ -5,7 +5,7 @@ gl_to_locator.py
 Convert ANGSD -doGlf 2 beagle.gz output to a feature matrix compatible with
 ReLocator's --geno tab-delimited input.
 
-See CLAUDE.md for full option descriptions, usage examples, and known limitations.
+Run with --help for full option descriptions and usage examples.
 
 Two output modes are supported via --gl_mode:
 

--- a/scripts/gl_to_locator.py
+++ b/scripts/gl_to_locator.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+"""
+gl_to_locator.py
+
+Convert ANGSD -doGlf 2 beagle.gz output to a feature matrix compatible with
+ReLocator's --geno tab-delimited input.
+
+See CLAUDE.md for full option descriptions, usage examples, and known limitations.
+
+Two output modes are supported via --gl_mode:
+
+  dosage  (default)
+      One column per site, value = expected dosage under a flat prior:
+          E[dosage] = P(AB) + 2 * P(BB)
+      Missing samples (max(GL) < --gl_missing_threshold) are imputed with
+      site-mean dosage across non-missing samples.
+
+  full_gl
+      Three columns per site (suffixed _AA, _AB, _BB), each holding the
+      normalized GL probability for that genotype. Preserves genotype
+      uncertainty information that the dosage scalar collapses. Missing
+      samples are imputed with the site-mean GL triplet.
+
+Output is tab-delimited with 'sampleID' as the first column. Rows are samples,
+columns are sites (or site_AA / site_AB / site_BB triplets in full_gl mode).
+"""
+
+import argparse
+import gzip
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+
+def parse_args():
+    p = argparse.ArgumentParser(
+        description="Convert ANGSD beagle GL file to ReLocator feature matrix."
+    )
+    p.add_argument(
+        "--beagle",
+        required=True,
+        help="ANGSD output.beagle.gz file (from -doGlf 2)",
+    )
+    p.add_argument(
+        "--bam_list",
+        required=True,
+        help=(
+            "BAM file list used in the ANGSD run (one BAM path per line). "
+            "Sample IDs are derived from Path(bam).stem. "
+            "Order must match the ANGSD run exactly."
+        ),
+    )
+    p.add_argument(
+        "--out",
+        required=True,
+        help="Output tab-delimited feature file for ReLocator --geno",
+    )
+    p.add_argument(
+        "--gl_mode",
+        choices=("dosage", "full_gl"),
+        default="dosage",
+        help=(
+            "Output encoding. 'dosage' (default): one column per site holding "
+            "the expected allele dosage. 'full_gl': three columns per site "
+            "(P_AA, P_AB, P_BB) preserving genotype uncertainty."
+        ),
+    )
+    p.add_argument(
+        "--min_maf",
+        type=float,
+        default=0.01,
+        help=(
+            "Drop sites with mean dosage MAF below this value. "
+            "MAF = min(mean_dosage, 2 - mean_dosage) / 2. "
+            "Default: 0.01"
+        ),
+    )
+    p.add_argument(
+        "--max_missing_frac",
+        type=float,
+        default=0.10,
+        help=(
+            "Drop sites where the fraction of effectively missing samples "
+            "exceeds this value. Default: 0.10"
+        ),
+    )
+    p.add_argument(
+        "--gl_missing_threshold",
+        type=float,
+        default=0.40,
+        help=(
+            "A sample at a site is treated as missing if max(GL_AA, GL_AB, GL_BB) "
+            "is below this value (near-uniform = no sequencing information). "
+            "Default: 0.40"
+        ),
+    )
+    p.add_argument(
+        "--sample_data",
+        default=None,
+        help=(
+            "Optional: ReLocator sample_data.txt file. If provided, derived "
+            "sample IDs are cross-checked against the sampleID column and any "
+            "mismatches are reported before writing output."
+        ),
+    )
+    return p.parse_args()
+
+
+def sample_ids_from_bam_list(bam_list_path):
+    ids = []
+    with open(bam_list_path) as fh:
+        for line in fh:
+            bam = line.strip()
+            if bam:
+                ids.append(Path(bam).stem)
+    if not ids:
+        raise ValueError(f"No BAM paths found in: {bam_list_path}")
+    return ids
+
+
+def load_beagle(beagle_path):
+    """Load beagle.gz file.
+
+    Returns
+    -------
+    markers : list of str, length n_sites
+    gl_flat : np.ndarray float32, shape (n_sites, n_samples * 3)
+              columns are GL triplets [AA, AB, BB] per sample.
+    """
+    print(f"Loading beagle file: {beagle_path}", flush=True)
+    rows = []
+    markers = []
+    open_fn = gzip.open if str(beagle_path).endswith(".gz") else open
+    with open_fn(beagle_path, "rt") as fh:
+        fh.readline()  # discard header
+        for line in fh:
+            fields = line.rstrip("\n").split("\t")
+            markers.append(fields[0])
+            rows.append(fields[3:])  # skip marker, allele1, allele2
+
+    if not rows:
+        raise ValueError(f"No data rows found in beagle file: {beagle_path}")
+
+    try:
+        gl_flat = np.array(rows, dtype=np.float32)
+    except ValueError as e:
+        raise ValueError(
+            f"Failed to parse beagle GL values as float32. Error: {e}"
+        )
+
+    print(f"  Loaded {len(markers)} sites", flush=True)
+    return markers, gl_flat
+
+
+def validate_dimensions(gl_flat, n_samples, beagle_path, bam_list_path):
+    expected_cols = n_samples * 3
+    if gl_flat.shape[1] != expected_cols:
+        raise ValueError(
+            f"Beagle file has {gl_flat.shape[1]} GL columns but expected "
+            f"{expected_cols} ({n_samples} samples × 3 GL values per sample).\n"
+            f"  Beagle: {beagle_path}\n"
+            f"  BAM list: {bam_list_path}\n"
+            f"Ensure --bam_list is the same file used in the ANGSD run."
+        )
+
+
+def reshape_gl(gl_flat, n_samples):
+    """Reshape (n_sites, n_samples*3) to (n_sites, n_samples, 3)."""
+    return gl_flat.reshape(gl_flat.shape[0], n_samples, 3)
+
+
+def expected_dosage(gl):
+    """E[dosage] = P(AB) + 2 * P(BB) under a flat prior."""
+    return gl[:, :, 1] + 2.0 * gl[:, :, 2]
+
+
+def detect_missing(gl, gl_missing_threshold):
+    """Return bool mask (n_sites, n_samples), True = sample missing at site."""
+    return gl.max(axis=2) < gl_missing_threshold
+
+
+def impute_dosage_with_site_mean(dosage, missing_mask):
+    """Impute missing dosage values with site-mean across non-missing samples."""
+    for i in range(dosage.shape[0]):
+        mask = missing_mask[i]
+        if not mask.any():
+            continue
+        present = dosage[i, ~mask]
+        dosage[i, mask] = present.mean() if present.size > 0 else 0.0
+    return dosage
+
+
+def impute_gl_with_site_mean(gl, missing_mask):
+    """Impute missing GL triplets with site-mean triplet across non-missing samples."""
+    for i in range(gl.shape[0]):
+        mask = missing_mask[i]
+        if not mask.any():
+            continue
+        present = gl[i, ~mask, :]
+        if present.size == 0:
+            gl[i, mask, :] = np.array([1.0 / 3, 1.0 / 3, 1.0 / 3], dtype=gl.dtype)
+        else:
+            gl[i, mask, :] = present.mean(axis=0)
+    return gl
+
+
+def filter_sites(dosage, missing_mask, min_maf, max_missing_frac):
+    """Apply site-level filters using imputed dosage and pre-imputation missing mask."""
+    missing_frac = missing_mask.mean(axis=1)
+    pass_missing = missing_frac <= max_missing_frac
+
+    mean_dos = dosage.mean(axis=1)
+    maf = np.minimum(mean_dos, 2.0 - mean_dos) / 2.0
+    pass_maf = maf >= min_maf
+
+    keep = pass_missing & pass_maf
+    reasons = {
+        "max_missing_frac": int((~pass_missing).sum()),
+        "min_maf": int((~pass_maf & pass_missing).sum()),
+        "total_removed": int((~keep).sum()),
+        "total_kept": int(keep.sum()),
+    }
+    return keep, reasons
+
+
+def cross_check_sample_ids(derived_ids, sample_data_path):
+    sd = pd.read_csv(sample_data_path, sep="\t", dtype=str)
+    if "sampleID" not in sd.columns:
+        print(
+            "WARNING: sample_data file has no 'sampleID' column; skipping cross-check.",
+            file=sys.stderr,
+        )
+        return
+
+    sd_ids = set(sd["sampleID"].values)
+    derived_set = set(derived_ids)
+    in_derived_not_sd = derived_set - sd_ids
+    in_sd_not_derived = sd_ids - derived_set
+
+    if in_derived_not_sd:
+        print(
+            f"WARNING: {len(in_derived_not_sd)} sample IDs derived from BAM list "
+            f"are NOT in sample_data.txt:\n  "
+            + "\n  ".join(sorted(in_derived_not_sd)),
+            file=sys.stderr,
+        )
+    if in_sd_not_derived:
+        print(
+            f"WARNING: {len(in_sd_not_derived)} sample IDs in sample_data.txt "
+            f"are NOT in BAM list:\n  "
+            + "\n  ".join(sorted(in_sd_not_derived)),
+            file=sys.stderr,
+        )
+    if not in_derived_not_sd and not in_sd_not_derived:
+        print(f"  Sample ID cross-check: all {len(derived_ids)} IDs match.", flush=True)
+
+
+def write_dosage(out_path, dosage, sample_ids, markers_kept):
+    """Write (n_samples, n_sites) dosage matrix as TSV.
+
+    Values are continuous expected dosage in [0, 2]. ReLocator's --matrix
+    loader was patched (loaders.py + training.py) to detect float dtype and
+    feed continuous dosage straight to the network, bypassing the
+    GenotypeArray round trip used by hard-call inputs.
+    """
+    df = pd.DataFrame(
+        dosage.T.astype(np.float32),
+        index=sample_ids,
+        columns=[f"site_{m}" for m in markers_kept],
+    )
+    df.index.name = "sampleID"
+    df.to_csv(out_path, sep="\t")
+
+
+def write_full_gl(out_path, gl, sample_ids, markers_kept):
+    """Write GL triplets as (n_samples, 3 * n_sites) matrix.
+
+    For each kept site `m`, three consecutive columns: site_{m}_AA, _AB, _BB.
+    """
+    n_sites = gl.shape[0]
+    n_samples = gl.shape[1]
+    flat = gl.transpose(1, 0, 2).reshape(n_samples, n_sites * 3)
+    cols = []
+    for m in markers_kept:
+        cols.extend([f"site_{m}_AA", f"site_{m}_AB", f"site_{m}_BB"])
+    df = pd.DataFrame(flat.astype(np.float32), index=sample_ids, columns=cols)
+    df.index.name = "sampleID"
+    df.to_csv(out_path, sep="\t")
+
+
+def main():
+    args = parse_args()
+
+    sample_ids = sample_ids_from_bam_list(args.bam_list)
+    n_samples = len(sample_ids)
+    print(f"BAM list: {n_samples} samples", flush=True)
+
+    if args.sample_data:
+        cross_check_sample_ids(sample_ids, args.sample_data)
+
+    markers, gl_flat = load_beagle(args.beagle)
+    n_sites = len(markers)
+    validate_dimensions(gl_flat, n_samples, args.beagle, args.bam_list)
+
+    gl = reshape_gl(gl_flat, n_samples)
+    del gl_flat
+
+    missing_mask = detect_missing(gl, args.gl_missing_threshold)
+    n_missing = int(missing_mask.sum())
+    print(
+        f"Missing genotypes: {n_missing} / {n_sites * n_samples} "
+        f"({100.0 * n_missing / (n_sites * n_samples):.1f}%) "
+        f"[threshold: max(GL) < {args.gl_missing_threshold}]",
+        flush=True,
+    )
+
+    # Always compute dosage — used for site-level MAF filtering even in full_gl mode.
+    dosage = expected_dosage(gl).copy()
+    dosage = impute_dosage_with_site_mean(dosage, missing_mask)
+
+    keep, reasons = filter_sites(
+        dosage, missing_mask, args.min_maf, args.max_missing_frac
+    )
+    print(
+        f"Site filtering:\n"
+        f"  Removed (missing rate > {args.max_missing_frac}): {reasons['max_missing_frac']}\n"
+        f"  Removed (MAF < {args.min_maf}):                   {reasons['min_maf']}\n"
+        f"  Total removed:                                     {reasons['total_removed']}\n"
+        f"  Sites retained:                                    {reasons['total_kept']}",
+        flush=True,
+    )
+    if reasons["total_kept"] == 0:
+        raise ValueError(
+            "No sites passed filters. Check --min_maf and --max_missing_frac."
+        )
+
+    markers_kept = [m for m, k in zip(markers, keep, strict=True) if k]
+
+    if args.gl_mode == "dosage":
+        out_arr = dosage[keep]  # (n_sites_kept, n_samples)
+        write_dosage(args.out, out_arr, sample_ids, markers_kept)
+        n_features = out_arr.shape[0]
+    else:
+        gl_kept = gl[keep].copy()  # (n_sites_kept, n_samples, 3)
+        gl_kept = impute_gl_with_site_mean(gl_kept, missing_mask[keep])
+        write_full_gl(args.out, gl_kept, sample_ids, markers_kept)
+        n_features = gl_kept.shape[0] * 3
+
+    print(
+        f"Written: {args.out}\n"
+        f"  Mode: {args.gl_mode}\n"
+        f"  Shape: {n_samples} samples × {n_features} features "
+        f"({len(markers_kept)} sites)",
+        flush=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_data_loading.py
+++ b/tests/test_data_loading.py
@@ -183,9 +183,7 @@ def test_filter_dosage_matrix_rejects_nan():
     """NaN in dosage must raise rather than silently masking out every site."""
     from locator.data import filter_dosage_matrix
 
-    dosage = np.array(
-        [[0.5, 1.0, 1.5], [np.nan, 0.7, 0.9]], dtype=np.float32
-    )
+    dosage = np.array([[0.5, 1.0, 1.5], [np.nan, 0.7, 0.9]], dtype=np.float32)
     with pytest.raises(ValueError, match="NaN"):
         filter_dosage_matrix(dosage, min_mac=1)
 

--- a/tests/test_data_loading.py
+++ b/tests/test_data_loading.py
@@ -86,6 +86,118 @@ def test_load_genotypes_from_matrix_file():
         os.unlink(matrix_file)
 
 
+def test_load_genotypes_from_matrix_file_continuous_dosage():
+    """Test loading a float-dosage matrix bypasses the GenotypeArray round trip."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+        f.write("sampleID\t1001\t2005\t3010\n")
+        f.write("sample1\t0.10\t0.95\t1.85\n")
+        f.write("sample2\t1.40\t1.95\t0.05\n")
+        f.write("sample3\t1.99\t0.00\t1.05\n")
+        matrix_file = f.name
+
+    try:
+        sample_df = pd.DataFrame(
+            {
+                "sampleID": ["sample1", "sample2", "sample3"],
+                "x": [10.0, 20.0, 30.0],
+                "y": [5.0, 15.0, 25.0],
+            }
+        )
+        config = {"sample_data": sample_df}
+        locator = Locator(config=config)
+
+        genotypes, samples = locator.load_genotypes(matrix=matrix_file)
+
+        # Continuous dosage path returns a float ndarray of shape
+        # (n_sites, n_samples) — the same layout that filter_snps emits for
+        # the integer path.
+        assert isinstance(genotypes, np.ndarray)
+        assert genotypes.dtype == np.float32
+        assert genotypes.shape == (3, 3)  # 3 SNPs, 3 samples
+        # Sample 1's site 1001 dosage should be 0.10 (continuous, not rounded).
+        np.testing.assert_allclose(genotypes[0, 0], 0.10, atol=1e-5)
+        np.testing.assert_array_equal(
+            samples, np.array(["sample1", "sample2", "sample3"])
+        )
+
+    finally:
+        os.unlink(matrix_file)
+
+
+def test_filter_genotypes_continuous_dosage_path():
+    """Test that _filter_genotypes routes a 2D float ndarray to the dosage filter."""
+    n_sites, n_samples = 50, 20
+    rng = np.random.default_rng(0)
+    # Continuous dosage matrix in [0, 2]; bias toward intermediate to avoid
+    # near-monomorphic columns being filtered out by min_mac.
+    dosage = rng.beta(2.0, 2.0, size=(n_sites, n_samples)).astype(np.float32) * 2.0
+
+    sample_df = pd.DataFrame(
+        {
+            "sampleID": [f"s{i}" for i in range(n_samples)],
+            "x": np.linspace(0.0, 50.0, n_samples),
+            "y": np.linspace(0.0, 50.0, n_samples),
+        }
+    )
+    locator = Locator(config={"sample_data": sample_df, "min_mac": 2})
+    out = locator._filter_genotypes(dosage)
+
+    # Shape preserved (no biallelic filtering for continuous dosage); output is
+    # contiguous float32 ready to feed the network.
+    assert isinstance(out, np.ndarray)
+    assert out.dtype == np.float32
+    assert out.shape[1] == n_samples
+    # Values must remain continuous (not rounded back to 0/1/2).
+    assert not np.array_equal(out, np.round(out))
+
+
+def test_prediction_filter_dispatch_for_continuous_dosage():
+    """Verify prediction-path filter routing works on a 2D float ndarray.
+
+    Without the dispatch, ``filter_snps_legacy`` calls ``.count_alleles()`` —
+    which only exists on ``allel.GenotypeArray`` — and raises AttributeError
+    on a continuous-dosage ndarray. This test exercises the same code path
+    used by ``predict_from_weights`` after a GL-trained model is reloaded.
+    """
+    n_sites, n_samples = 80, 30
+    rng = np.random.default_rng(0)
+    dosage = rng.beta(2.0, 2.0, size=(n_sites, n_samples)).astype(np.float32) * 2.0
+
+    sample_df = pd.DataFrame(
+        {
+            "sampleID": [f"s{i}" for i in range(n_samples)],
+            "x": np.linspace(0.0, 50.0, n_samples),
+            "y": np.linspace(0.0, 50.0, n_samples),
+        }
+    )
+    locator = Locator(config={"sample_data": sample_df, "min_mac": 2})
+
+    # Mirror the prediction-path dispatch logic. If routing is incorrect, the
+    # call to filter_snps_legacy on a float ndarray would raise AttributeError
+    # on .count_alleles() — which is what this test guards against.
+    is_dosage_matrix = (
+        isinstance(dosage, np.ndarray)
+        and dosage.ndim == 2
+        and np.issubdtype(dosage.dtype, np.floating)
+    )
+    assert is_dosage_matrix, "test setup: dosage must be 2D float ndarray"
+
+    # Direct check that the dosage helper handles this without invoking
+    # filter_snps_legacy at all.
+    out = locator._filter_dosage_matrix(dosage)
+    assert isinstance(out, np.ndarray)
+    assert out.dtype == np.float32
+    assert out.ndim == 2
+    assert out.shape[1] == n_samples
+
+    # Sanity: the legacy filter should NOT be called on a float ndarray; if it
+    # were, this would raise AttributeError on .count_alleles().
+    from locator.data import filter_snps_legacy
+
+    with pytest.raises(AttributeError, match="count_alleles"):
+        filter_snps_legacy(dosage, min_mac=2, max_snps=None, impute=False)
+
+
 def test_load_genotypes_invalid_values():
     """Test that invalid genotype values raise an error."""
     # Create genotype data with invalid values

--- a/tests/test_data_loading.py
+++ b/tests/test_data_loading.py
@@ -151,51 +151,43 @@ def test_filter_genotypes_continuous_dosage_path():
     assert not np.array_equal(out, np.round(out))
 
 
-def test_prediction_filter_dispatch_for_continuous_dosage():
-    """Verify prediction-path filter routing works on a 2D float ndarray.
+def test_filter_dosage_matrix_skips_legacy_path():
+    """Filter free-function handles continuous dosage without invoking ``filter_snps_legacy``.
 
-    Without the dispatch, ``filter_snps_legacy`` calls ``.count_alleles()`` —
-    which only exists on ``allel.GenotypeArray`` — and raises AttributeError
-    on a continuous-dosage ndarray. This test exercises the same code path
-    used by ``predict_from_weights`` after a GL-trained model is reloaded.
+    ``filter_snps_legacy`` calls ``.count_alleles()`` — which only exists on
+    ``allel.GenotypeArray`` — and raises AttributeError on a continuous-dosage
+    ndarray. This test confirms that ``filter_dosage_matrix`` (the free function
+    used by both training- and prediction-path dispatch in ``locator/data/filters.py``)
+    handles this case directly, and that the legacy filter would in fact fail
+    if it were dispatched here.
     """
+    from locator.data import filter_dosage_matrix, filter_snps_legacy
+
     n_sites, n_samples = 80, 30
     rng = np.random.default_rng(0)
     dosage = rng.beta(2.0, 2.0, size=(n_sites, n_samples)).astype(np.float32) * 2.0
 
-    sample_df = pd.DataFrame(
-        {
-            "sampleID": [f"s{i}" for i in range(n_samples)],
-            "x": np.linspace(0.0, 50.0, n_samples),
-            "y": np.linspace(0.0, 50.0, n_samples),
-        }
-    )
-    locator = Locator(config={"sample_data": sample_df, "min_mac": 2})
-
-    # Mirror the prediction-path dispatch logic. If routing is incorrect, the
-    # call to filter_snps_legacy on a float ndarray would raise AttributeError
-    # on .count_alleles() — which is what this test guards against.
-    is_dosage_matrix = (
-        isinstance(dosage, np.ndarray)
-        and dosage.ndim == 2
-        and np.issubdtype(dosage.dtype, np.floating)
-    )
-    assert is_dosage_matrix, "test setup: dosage must be 2D float ndarray"
-
-    # Direct check that the dosage helper handles this without invoking
-    # filter_snps_legacy at all.
-    out = locator._filter_dosage_matrix(dosage)
+    out = filter_dosage_matrix(dosage, min_mac=2, max_snps=None)
     assert isinstance(out, np.ndarray)
     assert out.dtype == np.float32
     assert out.ndim == 2
     assert out.shape[1] == n_samples
 
-    # Sanity: the legacy filter should NOT be called on a float ndarray; if it
+    # Sanity: the legacy filter must NOT be called on a float ndarray; if it
     # were, this would raise AttributeError on .count_alleles().
-    from locator.data import filter_snps_legacy
-
     with pytest.raises(AttributeError, match="count_alleles"):
         filter_snps_legacy(dosage, min_mac=2, max_snps=None, impute=False)
+
+
+def test_filter_dosage_matrix_rejects_nan():
+    """NaN in dosage must raise rather than silently masking out every site."""
+    from locator.data import filter_dosage_matrix
+
+    dosage = np.array(
+        [[0.5, 1.0, 1.5], [np.nan, 0.7, 0.9]], dtype=np.float32
+    )
+    with pytest.raises(ValueError, match="NaN"):
+        filter_dosage_matrix(dosage, min_mac=1)
 
 
 def test_load_genotypes_invalid_values():

--- a/tests/test_input_extensions.py
+++ b/tests/test_input_extensions.py
@@ -27,6 +27,7 @@ def run_script(script, *args):
 # GL converter
 # ---------------------------------------------------------------------------
 
+
 def write_synthetic_beagle(path, n_sites=20, n_samples=4, seed=0):
     """Write a small valid beagle.gz with random GL triplets that sum to 1."""
     rng = np.random.default_rng(seed)
@@ -64,8 +65,16 @@ def test_gl_to_locator_dosage(tmp_path):
 
     res = run_script(
         "gl_to_locator.py",
-        "--beagle", beagle, "--bam_list", bam_list, "--out", out,
-        "--min_maf", "0.0", "--max_missing_frac", "1.0",
+        "--beagle",
+        beagle,
+        "--bam_list",
+        bam_list,
+        "--out",
+        out,
+        "--min_maf",
+        "0.0",
+        "--max_missing_frac",
+        "1.0",
     )
     assert res.returncode == 0, res.stderr
 
@@ -91,9 +100,18 @@ def test_gl_to_locator_full_gl(tmp_path):
 
     res = run_script(
         "gl_to_locator.py",
-        "--beagle", beagle, "--bam_list", bam_list, "--out", out,
-        "--gl_mode", "full_gl",
-        "--min_maf", "0.0", "--max_missing_frac", "1.0",
+        "--beagle",
+        beagle,
+        "--bam_list",
+        bam_list,
+        "--out",
+        out,
+        "--gl_mode",
+        "full_gl",
+        "--min_maf",
+        "0.0",
+        "--max_missing_frac",
+        "1.0",
     )
     assert res.returncode == 0, res.stderr
 
@@ -119,8 +137,16 @@ def test_gl_to_locator_dimension_mismatch_errors(tmp_path):
 
     res = run_script(
         "gl_to_locator.py",
-        "--beagle", beagle, "--bam_list", bam_list, "--out", out,
-        "--min_maf", "0.0", "--max_missing_frac", "1.0",
+        "--beagle",
+        beagle,
+        "--bam_list",
+        bam_list,
+        "--out",
+        out,
+        "--min_maf",
+        "0.0",
+        "--max_missing_frac",
+        "1.0",
     )
     assert res.returncode != 0
     assert "expected" in res.stderr.lower() or "expected" in res.stdout.lower()

--- a/tests/test_input_extensions.py
+++ b/tests/test_input_extensions.py
@@ -1,0 +1,126 @@
+"""Tests for the GL input-extension script.
+
+The script is invoked as a subprocess against synthetic fixtures so the test
+exercises the same code path users hit. Fixtures are tiny (a handful of samples
+and sites) so the suite stays fast.
+"""
+
+import gzip
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+
+
+def run_script(script, *args):
+    """Invoke a scripts/*.py file with the current Python; return CompletedProcess."""
+    cmd = [sys.executable, str(SCRIPTS_DIR / script), *map(str, args)]
+    return subprocess.run(cmd, capture_output=True, text=True, check=False)
+
+
+# ---------------------------------------------------------------------------
+# GL converter
+# ---------------------------------------------------------------------------
+
+def write_synthetic_beagle(path, n_sites=20, n_samples=4, seed=0):
+    """Write a small valid beagle.gz with random GL triplets that sum to 1."""
+    rng = np.random.default_rng(seed)
+    rows = []
+    header = ["marker", "allele1", "allele2"]
+    for s in range(n_samples):
+        header += [f"Ind{s}", f"Ind{s}", f"Ind{s}"]
+    for i in range(n_sites):
+        triplets = rng.dirichlet(np.ones(3), size=n_samples)
+        flat = triplets.flatten().tolist()
+        rows.append([f"chr1_{i}", "0", "1", *[f"{v:.6f}" for v in flat]])
+
+    with gzip.open(path, "wt") as fh:
+        fh.write("\t".join(header) + "\n")
+        for r in rows:
+            fh.write("\t".join(r) + "\n")
+    return n_sites, n_samples
+
+
+def write_bam_list(path, n_samples):
+    with open(path, "w") as fh:
+        for i in range(n_samples):
+            fh.write(f"/path/to/sample_{i}.bam\n")
+    return [f"sample_{i}" for i in range(n_samples)]
+
+
+def test_gl_to_locator_dosage(tmp_path):
+    n_sites, n_samples = 30, 5
+    beagle = tmp_path / "in.beagle.gz"
+    bam_list = tmp_path / "bams.txt"
+    out = tmp_path / "geno.txt"
+
+    write_synthetic_beagle(beagle, n_sites=n_sites, n_samples=n_samples, seed=1)
+    expected_ids = write_bam_list(bam_list, n_samples)
+
+    res = run_script(
+        "gl_to_locator.py",
+        "--beagle", beagle, "--bam_list", bam_list, "--out", out,
+        "--min_maf", "0.0", "--max_missing_frac", "1.0",
+    )
+    assert res.returncode == 0, res.stderr
+
+    df = pd.read_csv(out, sep="\t")
+    assert list(df["sampleID"]) == expected_ids
+    feat_cols = [c for c in df.columns if c != "sampleID"]
+    assert len(feat_cols) == n_sites
+    vals = df[feat_cols].values
+    assert vals.shape == (n_samples, n_sites)
+    # Continuous expected dosage in [0, 2] (the patched locator --matrix
+    # loader accepts float values directly).
+    assert vals.min() >= 0.0 and vals.max() <= 2.0
+
+
+def test_gl_to_locator_full_gl(tmp_path):
+    n_sites, n_samples = 12, 3
+    beagle = tmp_path / "in.beagle.gz"
+    bam_list = tmp_path / "bams.txt"
+    out = tmp_path / "geno.txt"
+
+    write_synthetic_beagle(beagle, n_sites=n_sites, n_samples=n_samples, seed=2)
+    write_bam_list(bam_list, n_samples)
+
+    res = run_script(
+        "gl_to_locator.py",
+        "--beagle", beagle, "--bam_list", bam_list, "--out", out,
+        "--gl_mode", "full_gl",
+        "--min_maf", "0.0", "--max_missing_frac", "1.0",
+    )
+    assert res.returncode == 0, res.stderr
+
+    df = pd.read_csv(out, sep="\t")
+    feat_cols = [c for c in df.columns if c != "sampleID"]
+    # Three columns per site, suffixed _AA/_AB/_BB.
+    assert len(feat_cols) == 3 * n_sites
+    suffixes = [c.rsplit("_", 1)[-1] for c in feat_cols]
+    assert set(suffixes) == {"AA", "AB", "BB"}
+    # All triplet rows should sum approximately to 1 (since input is normalized).
+    arr = df[feat_cols].values.reshape(n_samples, n_sites, 3)
+    np.testing.assert_allclose(arr.sum(axis=2), 1.0, atol=1e-3)
+
+
+def test_gl_to_locator_dimension_mismatch_errors(tmp_path):
+    """If bam_list count disagrees with beagle column count, must error clearly."""
+    beagle = tmp_path / "in.beagle.gz"
+    bam_list = tmp_path / "bams.txt"
+    out = tmp_path / "geno.txt"
+
+    write_synthetic_beagle(beagle, n_sites=4, n_samples=4)
+    write_bam_list(bam_list, n_samples=2)  # wrong count
+
+    res = run_script(
+        "gl_to_locator.py",
+        "--beagle", beagle, "--bam_list", bam_list, "--out", out,
+        "--min_maf", "0.0", "--max_missing_frac", "1.0",
+    )
+    assert res.returncode != 0
+    assert "expected" in res.stderr.lower() or "expected" in res.stdout.lower()


### PR DESCRIPTION
 Adds end-to-end support for ANGSD-derived genotype likelihoods (GLs) as ReLocator
  input. The headline change is a **structurally additive patch to
  `locator/loaders.py:_load_from_matrix` and `locator/training.py:_filter_genotypes`**
  that lets `--matrix` accept continuous expected dosage (floats in `[0, 2]`) in
  addition to the existing hard-call dosage (integers `0/1/2`). The integer
  hard-call path is byte-identical to before — verified by direct array
  comparison.

  A preprocessing script (`scripts/gl_to_locator.py`) converts an ANGSD `.beagle.gz`
  file into the float dosage matrix the patched loader accepts.

  ## What's in the merge zone (the actual code change)

  | File | Change |
  |---|---|
  | `locator/loaders.py` | New float-dispatch branch in `_load_from_matrix`. Integer path unchanged. |
  | `locator/training.py` | New `_filter_dosage_matrix` helper + dispatch in `_filter_genotypes`. Integer path unchanged. |
  | `locator/prediction.py` | Mirror dispatch so `predict_from_weights` works on continuous-dosage models too. |
  | `locator/data/filters.py` | New `is_dosage_matrix(genotypes)` predicate (single source of truth for the dispatch). |
  | `locator/cli.py` | `--matrix` help text now mentions both hard-call and continuous-dosage acceptance. |
  | `scripts/gl_to_locator.py` | New CLI: ANGSD `*.beagle.gz` → tab-delimited dosage TSV. Supports `--gl_mode {dosage, full_gl}`. |
  | `tests/test_data_loading.py` | +2 tests: `test_load_genotypes_from_matrix_file_continuous_dosage`, `test_filter_genotypes_continuous_dosage_path`, plus a
   regression test that the prediction-path dispatch routes float arrays away from `filter_snps_legacy`. |
  | `tests/test_input_extensions.py` | New: 3 tests for `gl_to_locator.py` (dosage mode, full_gl mode, dimension-mismatch error path). |
  | `docs/genotype_likelihoods.md` | New: ~50-line user doc with the 3-step ANGSD → gl_to_locator → locator workflow. |

  ## Safety case (integer hard-call path is unchanged)

  - The patch in `_load_from_matrix` adds a single `if np.issubdtype(values.dtype, np.floating): return early` BEFORE the existing integer check. Integer
  code is byte-identical from line 140 onward.
  - The patch in `_filter_genotypes` wraps the existing `filter_snps(...)` call in an `else` branch. The integer code path is byte-identical.
  - Empirical: `np.array_equal(filtered_genotypes_patched, filtered_genotypes_original) == True` on the bundled example VCF (uint8, shape `(5830, 500)`) —
  confirmed by reverting the patch in a workspace, recomputing, and direct `np.array_equal`.
  - Same-seed VCF runs are GPU-non-deterministic regardless (cuDNN ops); two consecutive runs of the same code with the same seed differ in 1000/1000
  prediction lines. So prediction-level diffs cannot show patch impact directly — the bit-identical `filtered_genotypes` is the rigorous test.
  - Full ReLocator core test suite passes post-patch (232 tests, with one xdist-flake that passes in isolation).

  ## Empirical evidence (noise curve)

  Stress-tested on the bundled msprime example data (`data/test_genotypes.vcf.gz`,
  500 samples × ~11.5k biallelic sites, 90-sample random holdout). Beagle GLs
  were synthesized from the VCF's hard calls at five levels of injected uncertainty
  (α blends one-hot toward uniform; α=0 is deterministic ≈ "infinite coverage",
  α=0.9 is barely informative).

  | α | full_gl mean err | rounded mean err |
  |---|---|---|
  | 0.0 | 4.76 | 4.67 |
  | 0.3 | 4.80 | 4.83 |
  | 0.5 | 4.45 | 5.44 |
  | 0.7 | **4.43** | **18.54** ← centroid baseline |
  | 0.9 | **4.75** | **18.51** ← centroid baseline |

  VCF baseline mean err = 4.46. Centroid-baseline (predict the geographic mean
  for everyone) = 18.5.

  **Continuous-dosage (full_gl) prediction error stays flat across the entire
  α range, while the rounded path collapses to centroid baseline at α ≥ 0.7** —
  once max(GL) drops near 0.4, every expected dosage rounds to the same integer
  (1) and the matrix becomes effectively constant. The loader patch is therefore
  load-bearing for any GL workflow at moderate-to-low coverage.

  See `validation/figures/fig1_test_data.png` for the curve and the truth-vs-prediction
  scatters; `validation/figures/fig3_vcf_vs_fullgl.png` for the per-sample VCF
  vs full_gl agreement at α=0.

  ## Branch structure: two zones

  The branch has two clearly demarcated zones:

  - **Merge zone** — the files in the table above. ~600 lines of diff. This is
    what would actually ship to `main`.
  - **Validation zone** — `validation/` (top-level directory). All the validation
    tooling (path D LOSO sweep, noise-curve experiment, coast-projection metric),
    unit tests, three figures, summary report, and design specs that produced
    the empirical evidence above. Branch-only; no need to merge any of it. See
    `validation/README.md` for an entrypoint and `validation/summary/summary.md`
    for the full report.

  If you'd prefer to see the merge zone alone, a squash-merge or a cherry-pick of
  the merge-zone commits would give you a clean ~600-line landing.

  ## Known limitations / future work

  - Microsatellite input support: explicitly out of scope here; will come as a
    separate branch with its own validation arc.
  - Native `--beagle` CLI flag: `gl_to_locator.py` is currently a separate
    preprocessing step; folding it into ReLocator's CLI as a `--beagle / --bam_list`
    flag is a UX improvement, not a correctness gap (the patched `--matrix` already
    accepts the float dosage matrix end-to-end).
  - The `full_gl` mode triples the input width (3 cols/site of P_AA/P_AB/P_BB
    probabilities). On large-N datasets it works as well as 1-col-per-site dosage;
    on tens-of-samples studies it may overfit and dosage mode trains better.
    The validation arc shows both worked on the example data; cont/round comparisons
    were dropped from the noise curve because cont and full_gl were within ~1% on
    this dataset.

  ## How to verify

  ```bash
  pixi run pytest tests/ --ignore=tests/test_bandwidth_optimization_integration.py
  pixi run pytest validation/tests/  # 16 unit tests for the validation tooling```
