### PR TITLE
Speed up filter_snps; fix impute_missing AF formula

### DIFF
--- a/locator/data/_numba_kernels.py
+++ b/locator/data/_numba_kernels.py
@@ -1,0 +1,94 @@
+"""Numba-accelerated kernels for diploid genotype counts."""
+
+from __future__ import annotations
+
+import numpy as np
+
+try:
+    import numba
+
+    HAVE_NUMBA = True
+except ImportError:  # pragma: no cover - exercised only without numba installed
+    HAVE_NUMBA = False
+
+
+if HAVE_NUMBA:
+
+    @numba.njit(parallel=True, cache=True, boundscheck=False)
+    def _count_ref_alt_diploid(gt: np.ndarray):
+        n_snps = gt.shape[0]
+        n_samples = gt.shape[1]
+        ref = np.zeros(n_snps, dtype=np.int32)
+        alt = np.zeros(n_snps, dtype=np.int32)
+        has_higher = np.zeros(n_snps, dtype=np.bool_)
+        for i in numba.prange(n_snps):
+            r = 0
+            a = 0
+            h = False
+            for j in range(n_samples):
+                v0 = gt[i, j, 0]
+                v1 = gt[i, j, 1]
+                if v0 == 0:
+                    r += 1
+                elif v0 == 1:
+                    a += 1
+                elif v0 >= 2:
+                    h = True
+                if v1 == 0:
+                    r += 1
+                elif v1 == 1:
+                    a += 1
+                elif v1 >= 2:
+                    h = True
+            ref[i] = r
+            alt[i] = a
+            has_higher[i] = h
+        return ref, alt, has_higher
+
+
+def count_ref_alt_diploid(gt: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Parallel ref/alt counts per SNP for a diploid genotype array.
+
+    Replaces ``allel.GenotypeArray.count_alleles()`` for the common
+    diploid case. scikit-allel's kernel is Cython but single-threaded; on
+    multi-core hosts this kernel uses ``numba.prange`` along the SNP axis
+    and is typically an order of magnitude faster on WGS-scale inputs.
+
+    Parameters
+    ----------
+    gt : ndarray of shape (n_snps, n_samples, 2), int8 (or compatible)
+        Genotype codes: -1 = missing, 0 = ref, 1 = alt, >= 2 = higher
+        alleles (tri-allelic or more).
+
+    Returns
+    -------
+    ref : (n_snps,) int32
+        Per-SNP count of ref (allele 0) calls. Missing genotypes contribute
+        nothing.
+    alt : (n_snps,) int32
+        Per-SNP count of alt (allele 1) calls.
+    has_higher : (n_snps,) bool
+        True for any SNP where an allele >= 2 was observed.
+
+    Notes
+    -----
+    For ploidy != 2 or when numba is unavailable, the caller should use
+    scikit-allel's ``count_alleles()`` instead.
+    """
+    if not HAVE_NUMBA:
+        raise RuntimeError(
+            "count_ref_alt_diploid requires numba; install numba or use the "
+            "scikit-allel fallback path."
+        )
+    if gt.ndim != 3 or gt.shape[2] != 2:
+        raise ValueError(
+            f"count_ref_alt_diploid expects shape (n_snps, n_samples, 2); got {gt.shape}"
+        )
+    # numba dispatches on dtype, so non-int8 inputs would trigger a separate
+    # specialization; non-contiguous strides also defeat prange's sequential
+    # access pattern.
+    if gt.dtype != np.int8:
+        gt = gt.astype(np.int8, copy=False)
+    if not gt.flags["C_CONTIGUOUS"]:
+        gt = np.ascontiguousarray(gt)
+    return _count_ref_alt_diploid(gt)

--- a/locator/data/filters.py
+++ b/locator/data/filters.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
+import allel
 import numpy as np
 from tqdm import tqdm
+
+from ._numba_kernels import HAVE_NUMBA, count_ref_alt_diploid
 
 
 @dataclass
@@ -106,22 +109,32 @@ def normalize_locs_params(
     return params, unnormedlocs, normedlocs
 
 
-def impute_missing(genotypes) -> np.ndarray:
+def impute_missing(genotypes, alt_counts: Optional[np.ndarray] = None) -> np.ndarray:
     """Replace missing data with binomial draws from allele frequency.
 
     Args:
         genotypes: GenotypeArray with missing data
+        alt_counts: Optional precomputed per-site alt allele counts of shape
+            ``(n_sites,)``. When provided, the internal ``count_alleles()``
+            call is skipped — used by ``filter_snps`` to reuse counts from
+            its numba kernel.
 
     Returns
     -------
         Allele counts array with imputed values
     """
     print("imputing missing data")
-    dc = genotypes.count_alleles()[:, 1]
+    if alt_counts is None:
+        alt_counts = genotypes.count_alleles()[:, 1]
     ac = genotypes.to_allele_counts()[:, :, 1]
     missingness = genotypes.is_missing()
-    ninds = np.array([np.sum(x) for x in ~missingness])
-    af = np.array([dc[x] / (2 * ninds[x]) for x in range(len(ninds))])
+    # Denominator is the true non-missing allele count per site, not
+    # 2x the number of (partly-called) non-missing samples — a half-missing
+    # diploid call like (-1, 1) contributes one allele, not two, so the
+    # latter overcounts and can yield AF > 1 (or NaN at a fully missing site).
+    n_called_alleles = (np.asarray(genotypes.values) >= 0).sum(axis=(1, 2))
+    af = np.zeros(len(alt_counts), dtype=np.float64)
+    np.divide(alt_counts, n_called_alleles, out=af, where=n_called_alleles > 0)
 
     for i in tqdm(range(np.shape(ac)[0])):
         for j in range(np.shape(ac)[1]):
@@ -217,36 +230,52 @@ def filter_snps(
     n_mac_filtered = 0
     n_random_subset = 0
 
-    # Count alleles once and reuse
-    allele_counts = genotypes.count_alleles()
-
-    # Filter for biallelic sites
-    biallel = allele_counts.is_biallelic()
-    n_biallelic_filtered = n_snps_original - np.sum(biallel)
-
-    # Combine biallelic and MAC filters if needed
-    if min_mac > 1:
-        # Get derived allele counts from already computed allele_counts
-        derived_counts = allele_counts[biallel, 1]
-        mac_filter = derived_counts >= min_mac
-        n_mac_filtered = len(mac_filter) - np.sum(mac_filter)
-        # Combine filters
-        combined_filter = np.zeros(n_snps_original, dtype=bool)
-        combined_filter[biallel] = mac_filter
-        genotypes = genotypes[combined_filter, :, :]
+    # For diploid data use the parallel numba kernel — scikit-allel's
+    # count_alleles is single-threaded Cython and dominates wall time on
+    # WGS-scale inputs. Both branches produce a full-length ``biallel``
+    # mask and a full-length ``alt_counts`` array so downstream filter and
+    # impute logic is shared.
+    if (
+        HAVE_NUMBA
+        and isinstance(genotypes, allel.GenotypeArray)
+        and genotypes.ploidy == 2
+    ):
+        ref_counts, alt_counts, has_higher = count_ref_alt_diploid(
+            np.asarray(genotypes.values)
+        )
+        biallel = (ref_counts > 0) & (alt_counts > 0) & ~has_higher
     else:
-        genotypes = genotypes[biallel, :, :]
+        allele_counts = genotypes.count_alleles()
+        biallel = np.asarray(allele_counts.is_biallelic())
+        # max_allele can be 0 for an all-monomorphic input; in that case
+        # `biallel` is uniformly False and the alt count is just zeros.
+        if allele_counts.shape[1] > 1:
+            alt_counts = np.asarray(allele_counts[:, 1])
+        else:
+            alt_counts = np.zeros(n_snps_original, dtype=np.int32)
 
-    # Impute or convert to allele counts
+    n_biallelic_filtered = n_snps_original - np.sum(biallel)
+    if min_mac > 1:
+        combined_filter = biallel & (alt_counts >= min_mac)
+        n_mac_filtered = np.sum(biallel) - np.sum(combined_filter)
+    else:
+        combined_filter = biallel
+
+    passing_idx = np.where(combined_filter)[0]
+
+    # Subsample passing indices before materializing allele counts so
+    # to_allele_counts/impute only runs on the chosen subset.
+    if max_snps is not None and max_snps < len(passing_idx):
+        n_random_subset = len(passing_idx) - max_snps
+        sel = np.random.choice(len(passing_idx), max_snps, replace=False)
+        passing_idx = np.sort(passing_idx[sel])
+
+    genotypes = genotypes[passing_idx, :, :]
+
     if impute:
-        ac = impute_missing(genotypes)
+        ac = impute_missing(genotypes, alt_counts=alt_counts[passing_idx])
     else:
         ac = genotypes.to_allele_counts()[:, :, 1]
-
-    # Random subset if requested
-    if max_snps is not None and max_snps < ac.shape[0]:
-        n_random_subset = ac.shape[0] - max_snps
-        ac = ac[np.random.choice(range(ac.shape[0]), max_snps, replace=False), :]
 
     # Create stats
     stats = FilterStats(

--- a/pixi.toml
+++ b/pixi.toml
@@ -27,6 +27,7 @@ rasterio = ">=1.3"
 rasterstats = ">=0.19"
 shapely = ">=2.0"
 affine = ">=2.4"
+numba = ">=0.59"
 
 [pypi-dependencies]
 locator = { path = ".", editable = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "rasterstats",
     "shapely",
     "affine",
+    "numba>=0.59",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -216,6 +216,37 @@ class TestImputation:
         assert (imputed >= 0).all()
         assert (imputed <= 2).all()  # diploid, so max is 2
 
+    def test_impute_handles_half_and_fully_missing(self):
+        """Imputation must not produce NaN AF or AF>1 on edge cases.
+
+        - Half-missing calls (-1, x) overcount in a naive ninds denominator.
+        - A fully-missing site yields divide-by-zero in the AF formula.
+        Either case previously crashed np.random.binomial.
+        """
+        # Site 0: half-missing calls. Naive (alt / 2*ninds) = 3 / (2*3) = 0.5 OK
+        # Site 1: mostly half-missing alt calls. alt=3, ninds=3, naive=3/6=0.5 OK
+        # Site 2: pure alt half-missing. alt=4, ninds=4, naive=4/8=0.5 OK
+        # Site 3: mix of (1,1) and (-1, 1). alt=5, ninds=3, naive=5/6>0.83 OK
+        # Site 4: severe — all (1, 1) and one (-1, -1). alt=8, ninds=4,
+        #         naive=8/8=1.0 (boundary). Add (1, -1) to push naive past 1.
+        # Site 5: fully missing — should impute to 0 (AF=0) silently.
+        genotype_data = np.array(
+            [
+                [[-1, 1], [-1, 1], [-1, 1], [-1, 0], [-1, 0]],
+                [[-1, 1], [-1, 1], [-1, 1], [-1, 0], [0, 1]],
+                [[-1, 1], [-1, 1], [-1, 1], [-1, 1], [0, 1]],
+                [[1, 1], [1, 1], [-1, 1], [-1, 1], [0, 0]],
+                [[1, 1], [1, 1], [1, 1], [1, -1], [-1, -1]],
+                [[-1, -1], [-1, -1], [-1, -1], [-1, -1], [-1, -1]],
+            ],
+            dtype=np.int8,
+        )
+        genotypes = allel.GenotypeArray(genotype_data)
+        imputed = impute_missing(genotypes)
+        assert imputed.shape == (6, 5)
+        assert np.isfinite(imputed).all()
+        assert (imputed >= 0).all() and (imputed <= 2).all()
+
 
 def test_imports_backward_compatible():
     """Test that functions can be imported from main locator package."""


### PR DESCRIPTION
## Summary

- **`filter_snps` perf**: subsample passing indices before materialising allele counts; use a parallel numba kernel for ref/alt counting on the diploid path with a scikit-allel fallback for other ploidies. On WGS-scale inputs (~32M SNPs × 236 samples, `max_SNPs=1M`) drops `filter_snps` from ~88 s to ~5 s. Both branches now share post-count filter/stats logic and thread `alt_counts` into `impute_missing` to skip a redundant `count_alleles()` on the diploid + impute path.
- **`impute_missing` bugfix**: AF denominator used `2 × ninds` (where `ninds` counts call-level non-missing samples), which overcounts when diploid calls are half-missing — yielded `AF > 1` for those sites and `NaN` at fully-missing sites; either case crashed `np.random.binomial`. Now uses the true non-missing allele count per site with explicit zero-division handling.
- **Dep**: adds `numba>=0.59` to `pixi.toml` and `pyproject.toml`.

## Test plan

- [x] `pixi run pytest tests/test_filters.py` — 10/10 pass (1 new test exercises the previously-broken half-missing and fully-missing impute cases).
- [x] End-to-end correctness check on a fixture with tri- and quad-allelic sites: numba kernel agrees exactly with `scikit-allel.count_alleles` for ref/alt counts and `is_biallelic`.
- [x] Single-fold microbench on WGS 10x Actinemys, 1M SNPs: `filter_snps` 87.6 s → 5.25 s (full pipeline 291 s → 189 s).