### PR TITLE
Refactor parallel k-fold/LOO/holdout/ensemble/windowed to Ray actors

### DIFF
--- a/locator/core.py
+++ b/locator/core.py
@@ -47,12 +47,6 @@ def setup_gpu(gpu_number=None):
             # Use first GPU by default
             tf.config.set_visible_devices(gpus[0], "GPU")
             print(f"Using GPU 0: {gpus[0].name}")
-
-        # Enable memory growth for all visible GPUs
-        for gpu in tf.config.get_visible_devices("GPU"):
-            tf.config.experimental.set_memory_growth(gpu, True)
-
-        return True
     except RuntimeError as e:
         print(f"GPU configuration error: {e}")
         print("Falling back to CPU.")
@@ -61,6 +55,18 @@ def setup_gpu(gpu_number=None):
         print(f"GPU selection error: {e}")
         print("Falling back to CPU.")
         return False
+
+    # Memory growth is best-effort. When a Ray actor has already installed
+    # a hard memory cap via ``set_logical_device_configuration`` before
+    # Locator init runs, this call raises ValueError — that's fine, the
+    # GPU is still usable under the existing cap.
+    for gpu in tf.config.get_visible_devices("GPU"):
+        try:
+            tf.config.experimental.set_memory_growth(gpu, True)
+        except (RuntimeError, ValueError):
+            pass
+
+    return True
 
 
 class Locator(

--- a/locator/gpu_optimizer.py
+++ b/locator/gpu_optimizer.py
@@ -188,7 +188,9 @@ class GPUOptimizer:
                             )
                         ],
                     )
-            except RuntimeError as e:
+            except (RuntimeError, ValueError) as e:
+                # Both can fire when GPU is already configured — e.g. a Ray
+                # actor that installed a memory cap before Locator init runs.
                 warnings.warn(f"GPU memory configuration failed: {e}")
 
     @staticmethod

--- a/locator/parallel/_actor.py
+++ b/locator/parallel/_actor.py
@@ -269,17 +269,24 @@ def _spawn(actor_cls, gpu_ids, gpu_fraction, data_ref, gpu_mem_mb):
     """
     if not gpu_ids:
         gpu_assignments = [-1]
-        gpu_fraction = 0.0
+        effective_fraction = 0.0
     else:
         workers_per_gpu = max(1, int(round(1.0 / gpu_fraction)))
+        # Quantise the per-actor reservation so workers_per_gpu of them fit
+        # *exactly* in one GPU. Passing the caller's gpu_fraction verbatim
+        # (e.g. 0.34 × 3 = 1.02 per GPU) over-subscribes Ray's resource
+        # accounting and leaves the last actor unschedulable, hanging the
+        # pool's ``ready()`` barrier indefinitely. Actors are persistent
+        # (unlike tasks), so unschedulable actors never get a turn.
+        effective_fraction = 1.0 / workers_per_gpu
         gpu_assignments = [
             gpu_ids[i % len(gpu_ids)] for i in range(len(gpu_ids) * workers_per_gpu)
         ]
 
     actors = [
-        actor_cls.options(num_gpus=gpu_fraction).remote(
+        actor_cls.options(num_gpus=effective_fraction).remote(
             gpu_id=gpu_id,
-            gpu_fraction=gpu_fraction,
+            gpu_fraction=effective_fraction,
             data_ref=data_ref,
             gpu_mem_mb=gpu_mem_mb,
         )

--- a/locator/parallel/_actor.py
+++ b/locator/parallel/_actor.py
@@ -1,11 +1,18 @@
-"""Ray actor that runs many folds against a hot TF runtime.
+"""Ray actors that run many units of parallel work against a hot TF runtime.
 
-The previous task-based dispatcher recreated the Locator + Keras runtime per
-fold, paying a fresh XLA / autograph compile every time. For 100+ LOO folds
-that overhead dominates wall time. The actor here is created once per GPU
-slot (driven by ``gpu_fraction``) and serves folds via ``run_fold`` — the
-Locator instance, TF imports, and the JIT cache all survive between folds;
-only model weights are rebuilt.
+The previous task-based dispatchers (one Ray task per fold / replicate /
+window) recreated the Locator + Keras runtime per unit of work, paying a
+fresh XLA / autograph compile every time. For LOO with hundreds of folds
+or windowed analysis with thousands of windows, that overhead dominates
+wall time. Each actor here is created once per GPU slot (driven by
+``gpu_fraction``) and serves many units of work via a single method; the
+Locator instance, TF imports, and the JIT cache all survive between calls.
+
+Three actor classes share an init helper and differ only in their work
+method:
+    FoldWorker      train_holdout + predict_holdout (k-fold/LOO/holdout)
+    EnsembleActor   _train_single_fold (ensemble training)
+    WindowActor     train_window + predict_holdout (windowed analysis)
 """
 
 from __future__ import annotations
@@ -19,18 +26,39 @@ from ._helpers import _create_worker_locator, _setup_worker_env
 DEFAULT_GPU_MEM_MB = 80_000  # A100 80GB; safe default for the lab box.
 
 
+def _init_actor_runtime(gpu_id: int, gpu_fraction: float, gpu_mem_mb: int):
+    """Common GPU + TF setup for a Ray actor. Returns the imported ``tf`` module.
+
+    Sets ``CUDA_VISIBLE_DEVICES``, then before TF touches the device installs a
+    hard memory cap matching ``gpu_fraction`` so co-tenant actors can't
+    collectively blow the budget when XLA workspaces peak. Falls back to
+    ``memory_growth`` if the cap can't be set (TF already initialized).
+    """
+    _setup_worker_env(gpu_id)
+    import tensorflow as tf
+
+    gpus = tf.config.list_physical_devices("GPU")
+    if gpus and gpu_id != -1:
+        limit_mb = max(512, int(gpu_fraction * gpu_mem_mb * 0.95))
+        try:
+            tf.config.set_logical_device_configuration(
+                gpus[0],
+                [tf.config.LogicalDeviceConfiguration(memory_limit=limit_mb)],
+            )
+        except RuntimeError:
+            tf.config.experimental.set_memory_growth(gpus[0], True)
+
+    tf.get_logger().setLevel("ERROR")
+    return tf
+
+
 @ray.remote
 class FoldWorker:
-    """Long-lived Ray actor that processes folds against a hot TF runtime.
+    """Ray actor for k-fold / LOO / holdout-replicate work.
 
-    Lifecycle:
-        ``__init__``       configure GPU memory cap, import TF, instantiate Locator
-        ``run_fold(idx, holdout_indices)``  rebuild model + train + predict
-        ``ready()``        cheap probe used to surface init errors before dispatch
-
-    One actor per scheduling slot — ``num_gpus`` reserves the slot; the
-    memory cap below enforces it. The Locator + filtered genotype array
-    live on the actor and are reused for every fold it handles.
+    Each ``run_holdout`` call rebuilds the Locator's model from scratch (TF
+    runtime + autograph cache survives), trains with a different set of
+    held-out indices, and returns predictions for those samples.
     """
 
     def __init__(
@@ -40,34 +68,10 @@ class FoldWorker:
         data_ref,
         gpu_mem_mb: int = DEFAULT_GPU_MEM_MB,
     ):
-        _setup_worker_env(gpu_id)
-
-        import tensorflow as tf
-
-        gpus = tf.config.list_physical_devices("GPU")
-        if gpus and gpu_id != -1:
-            # Hard cap matching ``num_gpus`` so co-tenant actors can't
-            # collectively blow the device budget when XLA workspaces peak.
-            # ~5% margin for TF runtime overhead.
-            limit_mb = max(512, int(gpu_fraction * gpu_mem_mb * 0.95))
-            try:
-                tf.config.set_logical_device_configuration(
-                    gpus[0],
-                    [tf.config.LogicalDeviceConfiguration(memory_limit=limit_mb)],
-                )
-            except RuntimeError:
-                # set_logical_device_configuration is illegal once TF has
-                # touched the GPU. Memory growth keeps us alive but doesn't
-                # cap, so co-tenants can still OOM each other.
-                tf.config.experimental.set_memory_growth(gpus[0], True)
-
-        tf.get_logger().setLevel("ERROR")
-        self._tf = tf
+        self._tf = _init_actor_runtime(gpu_id, gpu_fraction, gpu_mem_mb)
         # Ray auto-dereferences the ObjectRef when it's passed as an actor
         # method arg; ``data_ref`` arrives as the resolved dict.
         self._data: Dict[str, Any] = data_ref
-        # Single Locator reused across folds; train_holdout overwrites all
-        # per-fold state so this is safe.
         self._locator = _create_worker_locator(self._data, "actor")
         self._base_out = self._data["config"]["out"]
 
@@ -75,12 +79,10 @@ class FoldWorker:
         """Probe that init completed without raising. Used to fail fast."""
         return True
 
-    def run_fold(self, fold_idx: int, holdout_indices: List[int]) -> Dict[str, Any]:
-        """Train one fold and return predictions for the held-out samples."""
+    def run_holdout(self, idx: int, holdout_indices: List[int]) -> Dict[str, Any]:
+        """Train one fold/replicate and return predictions for the held-out samples."""
         loc = self._locator
-        # Per-fold output prefix so any per-fold artifacts don't collide.
-        loc.config["out"] = f"{self._base_out}_fold{fold_idx}"
-
+        loc.config["out"] = f"{self._base_out}_fold{idx}"
         loc.train_holdout(
             genotypes=None,
             samples=self._data["samples"],
@@ -95,25 +97,178 @@ class FoldWorker:
             plot_map=False,
         )
         return {
-            "fold": fold_idx,
+            "idx": idx,
             "rows": preds[["sampleID", "x_pred", "y_pred"]].to_dict("records"),
         }
 
 
-def make_fold_workers(
-    gpu_ids: List[int],
-    gpu_fraction: float,
-    data_ref,
-    gpu_mem_mb: int = DEFAULT_GPU_MEM_MB,
-) -> List[Any]:
-    """Spawn one ``FoldWorker`` actor per scheduling slot, distributed across GPUs.
+@ray.remote
+class EnsembleActor:
+    """Ray actor for ensemble training (one model per fold).
 
-    Number of actors = ``len(gpu_ids) * round(1 / gpu_fraction)``; each actor
-    reserves ``gpu_fraction`` of one GPU via Ray. Actors are pinned to GPUs
-    round-robin.
+    Each ``run_ensemble_fold`` call runs ``_train_single_fold`` and returns the
+    fold's weights-file path + history + per-fold normalization parameters so
+    the dispatcher can rebuild the ensemble structure on the driver side.
+    """
+
+    def __init__(
+        self,
+        gpu_id: int,
+        gpu_fraction: float,
+        data_ref,
+        gpu_mem_mb: int = DEFAULT_GPU_MEM_MB,
+    ):
+        self._tf = _init_actor_runtime(gpu_id, gpu_fraction, gpu_mem_mb)
+        self._data: Dict[str, Any] = data_ref
+        self._locator = _create_worker_locator(self._data, "actor")
+        self._base_out = self._data["config"]["out"]
+
+    def ready(self) -> bool:
+        return True
+
+    def run_ensemble_fold(self, fold_idx: int) -> Dict[str, Any]:
+        loc = self._locator
+        loc.config["out"] = f"{self._base_out}_fold{fold_idx}"
+        save_fold_models = self._data["save_fold_models"]
+
+        model_info = loc._train_single_fold(
+            fold_idx=fold_idx,
+            index_set=self._data["fold_info"]["index_sets"][fold_idx],
+            filtered_genotypes=self._data["filtered_genotypes"],
+            samples=self._data["samples"],
+            locs=self._data["locs"],
+            augment_config=self._data.get("augment_config"),
+            save_fold_models=save_fold_models,
+            patience_multiplier=self._data["patience_multiplier"],
+            verbose=False,
+        )
+
+        weights_file = f"{loc.config['out']}.weights.h5" if save_fold_models else None
+
+        return {
+            "fold": fold_idx,
+            "model_info": {
+                "fold": model_info["fold"],
+                "weights_file": weights_file,
+                "norm_params": model_info["norm_params"],
+                "train_indices": model_info["train_indices"].tolist(),
+                "val_indices": model_info["val_indices"].tolist(),
+            },
+            "history": {
+                "loss": model_info["history"].history.get("loss", []),
+                "val_loss": model_info["history"].history.get("val_loss", []),
+            },
+            "final_loss": (
+                float(model_info["history"].history["loss"][-1])
+                if model_info["history"].history.get("loss")
+                else float("nan")
+            ),
+            "final_val_loss": (
+                float(model_info["history"].history["val_loss"][-1])
+                if model_info["history"].history.get("val_loss")
+                else float("nan")
+            ),
+        }
+
+
+@ray.remote
+class WindowActor:
+    """Ray actor for windowed-analysis work (one model per genomic window).
+
+    The Locator's full genotype array is materialised once on the actor; each
+    ``run_window`` call slices a different set of SNP indices and trains a
+    model for that window using a shared train/holdout split.
+    """
+
+    def __init__(
+        self,
+        gpu_id: int,
+        gpu_fraction: float,
+        data_ref,
+        gpu_mem_mb: int = DEFAULT_GPU_MEM_MB,
+    ):
+        self._tf = _init_actor_runtime(gpu_id, gpu_fraction, gpu_mem_mb)
+        self._data: Dict[str, Any] = data_ref
+        self._locator = _create_worker_locator(self._data, "actor")
+        self._base_out = self._data["config"]["out"]
+
+        # Materialise the full GenotypeArray once on the actor; window calls
+        # only slice ``window_snp_indices`` off it.
+        import allel
+
+        self._genotypes = allel.GenotypeArray(self._data["genotypes_array"])
+
+        loc = self._locator
+        loc.genotypes = self._genotypes
+        loc.index_set = self._data["index_set"]
+        loc.meanlong = self._data["meanlong"]
+        loc.sdlong = self._data["sdlong"]
+        loc.meanlat = self._data["meanlat"]
+        loc.sdlat = self._data["sdlat"]
+        loc.unnormedlocs = self._data["unnormedlocs"]
+
+    def ready(self) -> bool:
+        return True
+
+    def run_window(
+        self,
+        window_idx: int,
+        window_label: str,
+        window_chromosome,
+        window_start: int,
+        window_stop: int,
+        snp_indices: List[int],
+    ) -> Dict[str, Any]:
+        if len(snp_indices) == 0:
+            return {
+                "window_idx": window_idx,
+                "window_label": window_label,
+                "window_chromosome": window_chromosome,
+                "window_start": window_start,
+                "window_stop": window_stop,
+                "rows": None,
+                "n_snps": 0,
+            }
+
+        loc = self._locator
+        loc.config["out"] = f"{self._base_out}_win{window_idx}"
+        loc.train_window(
+            genotypes=self._genotypes,
+            samples=self._data["samples"],
+            window_snp_indices=snp_indices,
+            index_set=self._data["index_set"],
+            normalized_locs=self._data["normalized_locs"],
+        )
+        preds = loc.predict_holdout(
+            verbose=False,
+            return_df=True,
+            save_preds_to_disk=False,
+            plot_summary=False,
+            plot_map=False,
+        )
+        return {
+            "window_idx": window_idx,
+            "window_label": window_label,
+            "window_chromosome": window_chromosome,
+            "window_start": window_start,
+            "window_stop": window_stop,
+            "rows": (
+                preds[["sampleID", "x_pred", "y_pred"]].to_dict("records")
+                if preds is not None
+                else None
+            ),
+            "n_snps": len(snp_indices),
+        }
+
+
+def _spawn(actor_cls, gpu_ids, gpu_fraction, data_ref, gpu_mem_mb):
+    """Spawn ``actor_cls`` instances pinned round-robin across ``gpu_ids``.
+
+    Count of actors = ``len(gpu_ids) * round(1 / gpu_fraction)``, or 1 if
+    ``gpu_ids`` is empty (CPU only).
     """
     if not gpu_ids:
-        gpu_assignments = [-1]  # CPU-only
+        gpu_assignments = [-1]
         gpu_fraction = 0.0
     else:
         workers_per_gpu = max(1, int(round(1.0 / gpu_fraction)))
@@ -121,17 +276,31 @@ def make_fold_workers(
             gpu_ids[i % len(gpu_ids)] for i in range(len(gpu_ids) * workers_per_gpu)
         ]
 
-    actors = []
-    for gpu_id in gpu_assignments:
-        actor = FoldWorker.options(num_gpus=gpu_fraction).remote(
+    actors = [
+        actor_cls.options(num_gpus=gpu_fraction).remote(
             gpu_id=gpu_id,
             gpu_fraction=gpu_fraction,
             data_ref=data_ref,
             gpu_mem_mb=gpu_mem_mb,
         )
-        actors.append(actor)
-
-    # Block until every actor has run __init__ — surfaces config errors
-    # (bad GPU id, memory cap rejection, etc.) before we dispatch folds.
+        for gpu_id in gpu_assignments
+    ]
+    # Block until every actor has finished __init__; surfaces config errors
+    # (bad GPU id, memory cap rejection) before we dispatch work.
     ray.get([a.ready.remote() for a in actors])
     return actors
+
+
+def make_fold_workers(gpu_ids, gpu_fraction, data_ref, gpu_mem_mb=DEFAULT_GPU_MEM_MB):
+    """Spawn a pool of ``FoldWorker`` actors."""
+    return _spawn(FoldWorker, gpu_ids, gpu_fraction, data_ref, gpu_mem_mb)
+
+
+def make_ensemble_actors(gpu_ids, gpu_fraction, data_ref, gpu_mem_mb=DEFAULT_GPU_MEM_MB):
+    """Spawn a pool of ``EnsembleActor`` actors."""
+    return _spawn(EnsembleActor, gpu_ids, gpu_fraction, data_ref, gpu_mem_mb)
+
+
+def make_window_actors(gpu_ids, gpu_fraction, data_ref, gpu_mem_mb=DEFAULT_GPU_MEM_MB):
+    """Spawn a pool of ``WindowActor`` actors."""
+    return _spawn(WindowActor, gpu_ids, gpu_fraction, data_ref, gpu_mem_mb)

--- a/locator/parallel/_actor.py
+++ b/locator/parallel/_actor.py
@@ -1,0 +1,137 @@
+"""Ray actor that runs many folds against a hot TF runtime.
+
+The previous task-based dispatcher recreated the Locator + Keras runtime per
+fold, paying a fresh XLA / autograph compile every time. For 100+ LOO folds
+that overhead dominates wall time. The actor here is created once per GPU
+slot (driven by ``gpu_fraction``) and serves folds via ``run_fold`` — the
+Locator instance, TF imports, and the JIT cache all survive between folds;
+only model weights are rebuilt.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import ray
+
+from ._helpers import _create_worker_locator, _setup_worker_env
+
+DEFAULT_GPU_MEM_MB = 80_000  # A100 80GB; safe default for the lab box.
+
+
+@ray.remote
+class FoldWorker:
+    """Long-lived Ray actor that processes folds against a hot TF runtime.
+
+    Lifecycle:
+        ``__init__``       configure GPU memory cap, import TF, instantiate Locator
+        ``run_fold(idx, holdout_indices)``  rebuild model + train + predict
+        ``ready()``        cheap probe used to surface init errors before dispatch
+
+    One actor per scheduling slot — ``num_gpus`` reserves the slot; the
+    memory cap below enforces it. The Locator + filtered genotype array
+    live on the actor and are reused for every fold it handles.
+    """
+
+    def __init__(
+        self,
+        gpu_id: int,
+        gpu_fraction: float,
+        data_ref,
+        gpu_mem_mb: int = DEFAULT_GPU_MEM_MB,
+    ):
+        _setup_worker_env(gpu_id)
+
+        import tensorflow as tf
+
+        gpus = tf.config.list_physical_devices("GPU")
+        if gpus and gpu_id != -1:
+            # Hard cap matching ``num_gpus`` so co-tenant actors can't
+            # collectively blow the device budget when XLA workspaces peak.
+            # ~5% margin for TF runtime overhead.
+            limit_mb = max(512, int(gpu_fraction * gpu_mem_mb * 0.95))
+            try:
+                tf.config.set_logical_device_configuration(
+                    gpus[0],
+                    [tf.config.LogicalDeviceConfiguration(memory_limit=limit_mb)],
+                )
+            except RuntimeError:
+                # set_logical_device_configuration is illegal once TF has
+                # touched the GPU. Memory growth keeps us alive but doesn't
+                # cap, so co-tenants can still OOM each other.
+                tf.config.experimental.set_memory_growth(gpus[0], True)
+
+        tf.get_logger().setLevel("ERROR")
+        self._tf = tf
+        # Ray auto-dereferences the ObjectRef when it's passed as an actor
+        # method arg; ``data_ref`` arrives as the resolved dict.
+        self._data: Dict[str, Any] = data_ref
+        # Single Locator reused across folds; train_holdout overwrites all
+        # per-fold state so this is safe.
+        self._locator = _create_worker_locator(self._data, "actor")
+        self._base_out = self._data["config"]["out"]
+
+    def ready(self) -> bool:
+        """Probe that init completed without raising. Used to fail fast."""
+        return True
+
+    def run_fold(self, fold_idx: int, holdout_indices: List[int]) -> Dict[str, Any]:
+        """Train one fold and return predictions for the held-out samples."""
+        loc = self._locator
+        # Per-fold output prefix so any per-fold artifacts don't collide.
+        loc.config["out"] = f"{self._base_out}_fold{fold_idx}"
+
+        loc.train_holdout(
+            genotypes=None,
+            samples=self._data["samples"],
+            holdout_indices=holdout_indices,
+            filtered_genotypes=self._data["filtered_genotypes"],
+        )
+        preds = loc.predict_holdout(
+            verbose=False,
+            return_df=True,
+            save_preds_to_disk=False,
+            plot_summary=False,
+            plot_map=False,
+        )
+        return {
+            "fold": fold_idx,
+            "rows": preds[["sampleID", "x_pred", "y_pred"]].to_dict("records"),
+        }
+
+
+def make_fold_workers(
+    gpu_ids: List[int],
+    gpu_fraction: float,
+    data_ref,
+    gpu_mem_mb: int = DEFAULT_GPU_MEM_MB,
+) -> List[Any]:
+    """Spawn one ``FoldWorker`` actor per scheduling slot, distributed across GPUs.
+
+    Number of actors = ``len(gpu_ids) * round(1 / gpu_fraction)``; each actor
+    reserves ``gpu_fraction`` of one GPU via Ray. Actors are pinned to GPUs
+    round-robin.
+    """
+    if not gpu_ids:
+        gpu_assignments = [-1]  # CPU-only
+        gpu_fraction = 0.0
+    else:
+        workers_per_gpu = max(1, int(round(1.0 / gpu_fraction)))
+        gpu_assignments = [
+            gpu_ids[i % len(gpu_ids)] for i in range(len(gpu_ids) * workers_per_gpu)
+        ]
+
+    actors = []
+    for gpu_id in gpu_assignments:
+        actor = FoldWorker.options(num_gpus=gpu_fraction).remote(
+            gpu_id=gpu_id,
+            gpu_fraction=gpu_fraction,
+            data_ref=data_ref,
+            gpu_mem_mb=gpu_mem_mb,
+        )
+        actors.append(actor)
+
+    # Block until every actor has run __init__ — surfaces config errors
+    # (bad GPU id, memory cap rejection, etc.) before we dispatch folds.
+    ray.get([a.ready.remote() for a in actors])
+    return actors

--- a/locator/parallel/ensemble.py
+++ b/locator/parallel/ensemble.py
@@ -1,4 +1,14 @@
-"""Ensemble training parallel methods."""
+"""Ensemble training parallel methods.
+
+Each fold trains a single model via ``Locator._train_single_fold`` and
+returns model metadata + (optionally) a weights file. The dispatcher
+aggregates fold outputs into the ensemble structure on the driver side.
+
+Uses the ``EnsembleActor`` Ray actor so the TF runtime + Locator are paid
+once per GPU slot rather than per fold; XLA / autograph caches survive.
+"""
+
+from __future__ import annotations
 
 import os
 import time
@@ -7,100 +17,14 @@ from typing import Any, Dict, List, Optional
 import numpy as np
 import pandas as pd
 import ray
+from ray.util import ActorPool
 
+from ._actor import DEFAULT_GPU_MEM_MB, make_ensemble_actors
 from ._helpers import (
-    _collect_ray_results,
-    _create_worker_locator,
     _ensure_ray_initialized,
     _precalculate_bandwidth,
     _restore_bandwidth,
-    _setup_worker_env,
 )
-
-
-def _create_ray_ensemble_worker(gpu_fraction: float = 1.0):
-    """
-    Factory function to create a Ray worker for ensemble training.
-
-    Args:
-        gpu_fraction: Fraction of GPU to allocate per worker (value between 0.0 to 1.0)
-
-    Returns
-    -------
-        Ray remote function configured with specified GPU fraction
-    """
-
-    @ray.remote(num_gpus=gpu_fraction)
-    def _ray_ensemble_worker(fold_idx: int, gpu_id: int, data: dict) -> Dict[str, Any]:
-        """
-        Ray worker function that trains a single ensemble fold on a specific GPU.
-
-        Args:
-            fold_idx: Fold index
-            gpu_id: GPU ID to use
-            data: Shared data dict (resolved from Ray object store)
-
-        Returns
-        -------
-            Dictionary with model information and metadata
-        """
-        _setup_worker_env(gpu_id)
-
-        import tensorflow as tf
-
-        tf.get_logger().setLevel("ERROR")
-
-        print(f"Worker training ensemble fold {fold_idx} on GPU {gpu_id}")
-
-        filtered_genotypes = data["filtered_genotypes"]
-
-        locator = _create_worker_locator(data, f"fold{fold_idx}")
-
-        # Train single fold using existing method
-        start_time = time.time()
-        model_info = locator._train_single_fold(
-            fold_idx=fold_idx,
-            index_set=data["fold_info"]["index_sets"][fold_idx],
-            filtered_genotypes=filtered_genotypes,
-            samples=data["samples"],
-            locs=data["locs"],
-            augment_config=data.get("augment_config"),
-            save_fold_models=data["save_fold_models"],
-            patience_multiplier=data["patience_multiplier"],
-            verbose=False,
-        )
-        train_time = time.time() - start_time
-
-        # Add weights file path if saving
-        if data["save_fold_models"]:
-            model_info["weights_file"] = f"{locator.config['out']}.weights.h5"
-        else:
-            model_info["weights_file"] = None
-
-        result = {
-            "fold": fold_idx,
-            "gpu_id": gpu_id,
-            "train_time": train_time,
-            "model_info": {
-                "fold": model_info["fold"],
-                "weights_file": model_info["weights_file"],
-                "norm_params": model_info["norm_params"],
-                "train_indices": (model_info["train_indices"].tolist()),
-                "val_indices": (model_info["val_indices"].tolist()),
-            },
-            "history": {
-                "loss": model_info["history"].history.get("loss", []),
-                "val_loss": model_info["history"].history.get("val_loss", []),
-            },
-            "final_loss": float(model_info["history"].history["loss"][-1]),
-            "final_val_loss": float(model_info["history"].history["val_loss"][-1]),
-        }
-
-        tf.keras.backend.clear_session()
-
-        return result
-
-    return _ray_ensemble_worker
 
 
 def parallel_train_ensemble(  # noqa: C901
@@ -119,45 +43,16 @@ def parallel_train_ensemble(  # noqa: C901
     use_mixed_precision: Optional[bool] = None,
     patience_multiplier: float = 1.0,
     verbose: bool = True,
+    gpu_mem_mb: int = DEFAULT_GPU_MEM_MB,
 ) -> Dict[str, Any]:
-    """
-    Train an ensemble of k models in parallel across multiple GPUs using Ray.
+    """Train an ensemble of k models across multiple GPUs using Ray actors.
 
-    This is a parallel version of EnsembleMixin.train_ensemble() that distributes
-    fold training across available GPUs.
-
-    Args:
-        locator: Locator instance (for configuration and methods)
-        genotypes: GenotypeArray containing genetic data
-        samples: Array of sample IDs
-        k: Number of folds/models in ensemble (default: 5)
-        gpu_ids: List of GPU IDs to use (default: [0, 1])
-        gpu_fraction: Fraction of GPU to allocate per worker (default 1.0)
-            - 1.0: One full GPU per worker (safest, no GPU sharing)
-            - 0.5: Two workers can share one GPU
-            - 0.25: Four workers can share one GPU
-            - 0.0: CPU only execution
-        training_set_indices: Optional array of indices to restrict training
-        na_action: How to handle NA samples ('separate', 'exclude', 'fail')
-        augment_data: Whether to apply data augmentation (default: False)
-        flip_rate: Rate for genotype flipping augmentation (default: 0.05)
-        save_fold_models: Whether to save individual fold models (default: True)
-        use_model_manager: Whether to use model manager for saving (default: True)
-        use_mixed_precision: Whether to use mixed precision training (default: None, auto-detect)
-        patience_multiplier: Multiply patience for ensemble training (default: 1.0)
-        verbose: Whether to show training progress (default: True)
-
-    Returns
-    -------
-        dict: Dictionary containing:
-            - 'histories': List of training histories for each fold
-            - 'models': List of trained model configurations
-            - 'normalization_params': Averaged normalization parameters
-            - 'fold_info': Information about fold splits
+    See ``parallel_k_fold_holdouts`` for GPU/memory semantics. The return
+    dict matches the original API: ``histories``, ``models``,
+    ``normalization_params``, ``fold_info``, ``training_time``, ``parallel``.
     """
     _ensure_ray_initialized()
 
-    # Setup GPU optimizations for ensemble training in main process
     if verbose:
         mixed_precision_enabled = locator.setup_ensemble_gpu_optimization(
             use_mixed_precision
@@ -167,44 +62,28 @@ def parallel_train_ensemble(  # noqa: C901
     else:
         locator.setup_ensemble_gpu_optimization(use_mixed_precision)
 
-    # Store samples for later use
     locator.samples = samples
-
-    # Create folds using IndexSet
     fold_info = locator.create_ensemble_folds(
         genotypes, samples, k, training_set_indices, na_action
     )
-
-    # Filter SNPs once before training
     filtered_genotypes = locator._filter_genotypes(genotypes)
-
     _, locs = locator._resolve_locations(samples)
 
-    # Configure augmentation if requested
     augment_config = None
     if augment_data:
-        augment_config = {
-            "enabled": True,
-            "flip_rate": flip_rate,
-        }
+        augment_config = {"enabled": True, "flip_rate": flip_rate}
         locator.config["augmentation"] = augment_config
 
-    # Get sample data for serialization
-    sample_data = None
-    if hasattr(locator, "_sample_data_df"):
-        sample_data = locator._sample_data_df
+    sample_data = getattr(locator, "_sample_data_df", None)
 
-    # Pre-calculate KDE bandwidth if needed
     na_mask = np.isnan(locs[:, 0]) | np.isnan(locs[:, 1])
-    bw_locs = locs[~na_mask]
     bw_calculated, bw_original = _precalculate_bandwidth(
         locator,
-        bw_locs,
-        f"ensemble_k{k}_n{len(bw_locs)}",
+        locs[~na_mask],
+        f"ensemble_k{k}_n{int((~na_mask).sum())}",
         verbose,
     )
 
-    # Share only filtered array via Ray object store
     data_ref = ray.put(
         {
             "filtered_genotypes": filtered_genotypes,
@@ -219,113 +98,94 @@ def parallel_train_ensemble(  # noqa: C901
         }
     )
 
-    if verbose:
-        print(f"Training {k}-fold ensemble across GPUs {gpu_ids} using Ray...")
-
-    start_time = time.time()
-
-    _ray_ensemble_worker = _create_ray_ensemble_worker(gpu_fraction)
-
-    # Submit all folds to Ray
-    futures = []
-    for fold_idx in range(k):
-        if len(gpu_ids) == 0:
-            gpu_id = -1
-        else:
-            gpu_id = gpu_ids[fold_idx % len(gpu_ids)]
-
-        future = _ray_ensemble_worker.remote(
-            fold_idx=fold_idx, gpu_id=gpu_id, data=data_ref
-        )
-        futures.append(future)
-        if verbose:
-            device_str = "CPU" if gpu_id == -1 else f"GPU {gpu_id}"
-            print(f"Submitted fold {fold_idx} to {device_str}")
-
-    # Wait for all folds to complete
-    results = _collect_ray_results(
-        futures,
-        desc="Folds completed",
-        postfix_fn=lambda r: (
-            f"Last: Fold {r['fold']}, "
-            f"GPU {r['gpu_id']}, "
-            f"Final loss: {r['final_loss']:.4f}"
-        ),
-        verbose=verbose,
+    actors = make_ensemble_actors(
+        gpu_ids=gpu_ids,
+        gpu_fraction=gpu_fraction,
+        data_ref=data_ref,
+        gpu_mem_mb=gpu_mem_mb,
     )
-
-    total_time = time.time() - start_time
-
     if verbose:
         print(
-            f"\nCompleted ensemble training in "
-            f"{total_time:.1f}s "
-            f"({total_time / k:.1f}s per fold)"
+            f"Spawned {len(actors)} EnsembleActor actors across GPUs {gpu_ids}; "
+            f"training {k} folds (gpu_fraction={gpu_fraction})."
         )
 
-        # Show speedup vs sequential
-        if len(gpu_ids) > 0:
-            num_gpus = len(set(gpu_ids))
-            estimated_speedup = k / num_gpus
-            print(
-                f"Estimated speedup: {estimated_speedup:.1f}x "
-                f"(using {num_gpus} "
-                f"GPU{'s' if num_gpus > 1 else ''})"
+    pool = ActorPool(actors)
+    start_time = time.time()
+
+    pbar = None
+    if verbose:
+        try:
+            from tqdm import tqdm
+
+            pbar = tqdm(total=k, desc="Folds")
+        except ImportError:
+            pass
+
+    results = []
+    for result in pool.map_unordered(
+        lambda actor, fold_idx: actor.run_ensemble_fold.remote(fold_idx),
+        list(range(k)),
+    ):
+        results.append(result)
+        if pbar is not None:
+            pbar.set_postfix_str(
+                f"Last: Fold {result['fold']}, Final loss: {result['final_loss']:.4f}"
             )
-        else:
-            print("CPU mode - no GPU speedup available")
+            pbar.update(1)
+
+    if pbar is not None:
+        pbar.close()
+
+    total_time = time.time() - start_time
+    if verbose:
+        print(
+            f"\nCompleted ensemble training in {total_time:.1f}s "
+            f"({total_time / max(k, 1):.1f}s per fold)"
+        )
+
+    for actor in actors:
+        ray.kill(actor)
 
     _restore_bandwidth(locator, bw_calculated, bw_original)
 
-    # Aggregate results (sort by fold index)
     results_sorted = sorted(results, key=lambda x: x["fold"])
 
-    # Store results on locator instance
     locator._ensemble_genotypes = genotypes
     locator._ensemble_fold_info = fold_info
     locator._ensemble_models = []
     locator._ensemble_histories = []
     locator._ensemble_norm_params = []
 
+    class _HistoryStub:
+        def __init__(self, history_dict):
+            self.history = history_dict
+
     for result in results_sorted:
-        model_info = result["model_info"]
-        model_info["model"] = None
-        model_info["train_indices"] = np.array(model_info["train_indices"])
-        model_info["val_indices"] = np.array(model_info["val_indices"])
+        m = result["model_info"]
+        m["model"] = None
+        m["train_indices"] = np.array(m["train_indices"])
+        m["val_indices"] = np.array(m["val_indices"])
+        m["history"] = _HistoryStub(result["history"])
+        locator._ensemble_models.append(m)
+        locator._ensemble_histories.append(m["history"])
+        locator._ensemble_norm_params.append(m["norm_params"])
 
-        class HistoryStub:
-            def __init__(self, history_dict):
-                self.history = history_dict
-
-        model_info["history"] = HistoryStub(result["history"])
-
-        locator._ensemble_models.append(model_info)
-        locator._ensemble_histories.append(model_info["history"])
-        locator._ensemble_norm_params.append(model_info["norm_params"])
-
-    # Calculate averaged normalization parameters
     avg_norm_params = locator._average_normalization_params(
         locator._ensemble_norm_params
     )
-
-    # Store averaged parameters on instance
     locator.meanlong = avg_norm_params["meanlong"]
     locator.sdlong = avg_norm_params["sdlong"]
     locator.meanlat = avg_norm_params["meanlat"]
     locator.sdlat = avg_norm_params["sdlat"]
 
-    # Save ensemble using model manager if requested
     if use_model_manager and save_fold_models:
-        from locator.ensemble_model_manager import (
-            EnsembleModelManager,
-        )
+        from locator.ensemble_model_manager import EnsembleModelManager
 
         model_manager = EnsembleModelManager(f"{locator.config['out']}_ensemble")
-
         serializable_config = {
             k_: v for k_, v in locator.config.items() if not isinstance(v, pd.DataFrame)
         }
-
         ensemble_metadata = {
             "k_folds": k,
             "na_action": na_action or locator.na_action,
@@ -336,34 +196,24 @@ def parallel_train_ensemble(  # noqa: C901
         }
 
         models_loaded = False
-        if verbose:
-            print("Checking for saved model weights...")
-
-        for i, m_info in enumerate(locator._ensemble_models):
-            if m_info["weights_file"] and os.path.exists(m_info["weights_file"]):
-                if not models_loaded and verbose:
-                    print("Loading models for ensemble manager...")
+        for m in locator._ensemble_models:
+            wf = m["weights_file"]
+            if wf and os.path.exists(wf):
                 models_loaded = True
                 model = locator._create_model(input_shape=filtered_genotypes.shape[0])
-                model.load_weights(m_info["weights_file"])
-                m_info["model"] = model
-            else:
-                if verbose and m_info["weights_file"]:
-                    print(
-                        "Warning: Expected weights file "
-                        f"not found: {m_info['weights_file']}"
-                    )
+                model.load_weights(wf)
+                m["model"] = model
+            elif verbose and wf:
+                print(f"Warning: Expected weights file not found: {wf}")
 
         if models_loaded:
             model_manager.save_ensemble(locator._ensemble_models, ensemble_metadata)
             if verbose:
                 print(f"Saved ensemble to {model_manager.ensemble_dir}")
-        else:
-            if verbose:
-                print(
-                    "Models were saved individually by workers,"
-                    " skipping ensemble manager."
-                )
+        elif verbose:
+            print(
+                "Models were saved individually by workers; skipping ensemble manager."
+            )
 
     return {
         "histories": locator._ensemble_histories,

--- a/locator/parallel/holdout.py
+++ b/locator/parallel/holdout.py
@@ -1,109 +1,101 @@
-"""Holdout replicate parallel methods."""
+"""Holdout-replicate parallel methods.
 
+A holdout replicate is just a k-fold-style train_holdout call with a chosen
+set of held-out indices; the work is the same as one fold of k-fold CV. This
+module dispatches replicates across the same ``FoldWorker`` actor pool used
+by ``locator.parallel.kfold`` and aggregates predictions into the wide-format
+DataFrame ``[sampleID, x_rep0, y_rep0, x_rep1, y_rep1, ...]`` that the
+existing API contract requires.
+
+Per-replicate predictions are streamed to a long-format checkpoint CSV
+(``{out}_holdouts_chunks.csv``) as each replicate completes; the wide-format
+output is pivoted from that file at the end. ``resume=True`` (default) skips
+replicates already present in the checkpoint.
+"""
+
+from __future__ import annotations
+
+import os
 import time
-from typing import Any, Dict, List, Optional, Union
+from typing import List, Optional, Union
 
 import numpy as np
 import pandas as pd
 import ray
+from ray.util import ActorPool
 
+from ._actor import DEFAULT_GPU_MEM_MB, make_fold_workers
 from ._helpers import (
-    _collect_ray_results,
-    _create_worker_locator,
     _ensure_ray_initialized,
     _precalculate_bandwidth,
     _restore_bandwidth,
-    _setup_worker_env,
 )
 
 
-def _create_ray_holdout_worker(gpu_fraction: float = 1.0):
-    """
-    Factory function to create a Ray worker for holdout analysis.
+def _holdout_chunk_path(locator) -> str:
+    return f"{locator.config['out']}_holdouts_chunks.csv"
 
-    Args:
-        gpu_fraction: Fraction of GPU to allocate per worker
 
-    Returns
-    -------
-        Ray remote function configured with specified GPU fraction
-    """
+def _holdout_output_path(locator) -> str:
+    return f"{locator.config['out']}_holdouts_predlocs.csv"
 
-    @ray.remote(num_gpus=gpu_fraction)
-    def _ray_holdout_worker(
-        rep_idx: int,
-        gpu_id: int,
-        data: dict,
-        holdout_indices: np.ndarray,
-    ) -> Dict[str, Any]:
-        """
-        Ray worker function that runs a single holdout replicate on a specific GPU.
 
-        Args:
-            rep_idx: Replicate index
-            gpu_id: GPU ID to use
-            data: Shared data dict (resolved from Ray object store)
-            holdout_indices: Indices to hold out for this replicate
+def _resume_completed_reps(chunk_path: str) -> set[int]:
+    if not os.path.exists(chunk_path):
+        return set()
+    try:
+        existing = pd.read_csv(chunk_path)
+    except (pd.errors.EmptyDataError, FileNotFoundError):
+        return set()
+    if existing.empty or "rep" not in existing.columns:
+        return set()
+    return set(existing["rep"].astype(int).tolist())
 
-        Returns
-        -------
-            Dictionary with predictions and metadata
-        """
-        _setup_worker_env(gpu_id)
 
-        import allel
-        import tensorflow as tf
+def _append_rep_to_chunks(chunk_path: str, rep: int, rows: list) -> None:
+    write_header = not os.path.exists(chunk_path) or os.path.getsize(chunk_path) == 0
+    with open(chunk_path, "a") as f:
+        if write_header:
+            f.write("sampleID,x_pred,y_pred,rep\n")
+        for r in rows:
+            f.write(f"{r['sampleID']},{r['x_pred']},{r['y_pred']},{rep}\n")
 
-        tf.get_logger().setLevel("ERROR")
 
-        print(f"Worker processing replicate {rep_idx} on GPU {gpu_id}")
+def _resolve_holdout_indices(
+    holdout_indices,
+    holdout_sample_ids,
+    samples,
+    known_idx,
+    k,
+    n_reps,
+):
+    """Materialise per-replicate holdout index arrays from the various input forms."""
+    if holdout_sample_ids is not None:
+        samples_list = samples.tolist() if hasattr(samples, "tolist") else list(samples)
+        if isinstance(holdout_sample_ids[0], str):
+            try:
+                fixed = [samples_list.index(sid) for sid in holdout_sample_ids]
+            except ValueError:
+                missing = [sid for sid in holdout_sample_ids if sid not in samples_list]
+                raise ValueError(f"Sample IDs not found in samples list: {missing}")
+            return [fixed for _ in range(n_reps)], len(holdout_sample_ids)
+        all_indices = []
+        for rep_ids in holdout_sample_ids:
+            try:
+                rep_indices = [samples_list.index(sid) for sid in rep_ids]
+            except ValueError:
+                missing = [sid for sid in rep_ids if sid not in samples_list]
+                raise ValueError(f"Sample IDs not found in samples list: {missing}")
+            all_indices.append(rep_indices)
+        return all_indices, k
 
-        locator = _create_worker_locator(data, f"rep{rep_idx}")
-
-        # Use pre-filtered allele counts if available
-        filtered = data.get("filtered_genotypes")
-        if filtered is not None:
-            genotypes = None
-        elif "genotypes_array" in data:
-            genotypes = allel.GenotypeArray(data["genotypes_array"])
+    all_indices = []
+    for rep in range(n_reps):
+        if holdout_indices is not None and rep < len(holdout_indices):
+            all_indices.append(list(holdout_indices[rep]))
         else:
-            raise ValueError("Worker received neither filtered nor raw genotypes")
-
-        # Train with holdout
-        start_time = time.time()
-        history = locator.train_holdout(
-            genotypes=genotypes,
-            samples=data["samples"],
-            holdout_indices=holdout_indices,
-            filtered_genotypes=filtered,
-        )
-        train_time = time.time() - start_time
-
-        # Make predictions
-        predictions = locator.predict_holdout(
-            verbose=False,
-            return_df=True,
-            save_preds_to_disk=False,
-            plot_summary=False,
-            plot_map=False,
-        )
-
-        tf.keras.backend.clear_session()
-
-        return {
-            "rep": rep_idx,
-            "gpu_id": gpu_id,
-            "train_time": train_time,
-            "predictions": predictions.to_dict("records"),
-            "holdout_indices": holdout_indices.tolist(),
-            "final_loss": (
-                float(history.history["loss"][-1])
-                if history and "loss" in history.history
-                else None
-            ),
-        }
-
-    return _ray_holdout_worker
+            all_indices.append(np.random.choice(known_idx, k, replace=False).tolist())
+    return all_indices, k
 
 
 def parallel_holdouts(  # noqa: C901
@@ -120,108 +112,45 @@ def parallel_holdouts(  # noqa: C901
     save_full_pred_matrix: bool = True,
     verbose: bool = True,
     na_action: Optional[str] = None,
+    resume: bool = True,
+    gpu_mem_mb: int = DEFAULT_GPU_MEM_MB,
 ) -> Union[pd.DataFrame, None]:
-    """
-    Run multiple holdout replicates in parallel across multiple GPUs using Ray.
+    """Run multiple holdout replicates in parallel via a ``FoldWorker`` actor pool.
 
-    This is a parallel version of AnalysisMixin.run_holdouts() that distributes
-    replicates across available GPUs.
-
-    Args:
-        locator: Locator instance (for configuration and methods)
-        genotypes: GenotypeArray
-        samples: List of sample IDs
-        k: Number of samples to hold out in each replicate
-        n_reps: Number of holdout replicates to run
-        holdout_indices: Optional list of lists, each containing indices to hold out
-        holdout_sample_ids: Optional list of sample IDs to hold out. If provided,
-            these specific samples will be held out (overrides k and holdout_indices).
-            Can be a single list (used for all replicates) or list of lists
-            (different samples per replicate).
-        gpu_ids: List of GPU IDs to use
-        gpu_fraction: Fraction of GPU to allocate per worker (default 1.0)
-        return_df: Whether to return DataFrame with all predictions
-        save_full_pred_matrix: Whether to save full prediction matrix to disk
-        verbose: Whether to show training progress and intermediate output
-        na_action: How to handle NA samples ('separate', 'exclude', 'fail').
-            If None, uses locator.na_action
-
-    Returns
-    -------
-        pandas.DataFrame or None: If return_df=True, returns DataFrame with predictions
-            for each holdout replicate containing columns:
-            - sampleID: Sample identifier
-            - x_rep0, y_rep0: Predictions from replicate 0
-            - x_rep1, y_rep1: Predictions from replicate 1
-            - ... and so on for all replicates
-
-            Note: True locations are not included. Merge with sample metadata to calculate errors.
+    See ``parallel_k_fold_holdouts`` for the GPU/memory semantics. Output is
+    in wide format (``x_rep0, y_rep0, x_rep1, ...``) to match the existing
+    API contract; a long-format per-replicate checkpoint is written
+    alongside for resume safety.
     """
     _ensure_ray_initialized()
 
-    na_action, status = locator._validate_na_action(
-        samples, na_action, "Holdout analysis"
-    )
-
+    na_action, _ = locator._validate_na_action(samples, na_action, "Holdout analysis")
     sample_data, locs = locator._resolve_locations(samples)
 
-    # Get indices of samples with known locations
-    known_mask = ~np.isnan(locs[:, 0])
-    known_idx = np.where(known_mask)[0]
-
+    known_idx = np.where(~np.isnan(locs[:, 0]))[0]
     if k >= len(known_idx):
         raise ValueError(
-            f"k ({k}) must be less than number of samples with "
-            f"known locations ({len(known_idx)})"
+            f"k ({k}) must be less than number of samples with known locations "
+            f"({len(known_idx)})"
         )
 
-    # Pre-calculate KDE bandwidth if needed
-    bw_locs = locs[known_idx]
     bw_calculated, bw_original = _precalculate_bandwidth(
         locator,
-        bw_locs,
-        f"holdouts_k{k}_n{len(bw_locs)}",
+        locs[known_idx],
+        f"holdouts_k{k}_n{len(known_idx)}",
         verbose,
     )
 
-    # Handle holdout_sample_ids if provided
-    if holdout_sample_ids is not None:
-        if hasattr(samples, "tolist"):
-            samples_list = samples.tolist()
-        else:
-            samples_list = list(samples)
+    all_holdout_indices, k = _resolve_holdout_indices(
+        holdout_indices,
+        holdout_sample_ids,
+        samples,
+        known_idx,
+        k,
+        n_reps,
+    )
+    n_reps = len(all_holdout_indices)
 
-        if isinstance(holdout_sample_ids[0], str):
-            try:
-                holdout_indices = [
-                    [samples_list.index(sid) for sid in holdout_sample_ids]
-                ]
-            except ValueError:
-                missing = [sid for sid in holdout_sample_ids if sid not in samples_list]
-                raise ValueError(f"Sample IDs not found in samples list: {missing}")
-            holdout_indices = holdout_indices * n_reps
-            k = len(holdout_sample_ids)
-        else:
-            holdout_indices = []
-            for rep_ids in holdout_sample_ids:
-                try:
-                    rep_indices = [samples_list.index(sid) for sid in rep_ids]
-                except ValueError:
-                    missing = [sid for sid in rep_ids if sid not in samples_list]
-                    raise ValueError(f"Sample IDs not found in samples list: {missing}")
-                holdout_indices.append(rep_indices)
-            n_reps = len(holdout_indices)
-
-    # Generate holdout indices for all replicates
-    all_holdout_indices = []
-    for rep in range(n_reps):
-        if holdout_indices is not None and rep < len(holdout_indices):
-            rep_holdout_idx = holdout_indices[rep]
-        else:
-            rep_holdout_idx = np.random.choice(known_idx, k, replace=False)
-        all_holdout_indices.append(rep_holdout_idx)
-
-    # Pre-filter once so workers share a small array instead of the full genotypes
     filtered_genotypes = locator._filter_genotypes(genotypes)
     if verbose:
         print(
@@ -229,87 +158,98 @@ def parallel_holdouts(  # noqa: C901
             f"{filtered_genotypes.shape[0]:,} SNPs"
         )
 
-    data_ref = ray.put(
-        {
-            "filtered_genotypes": filtered_genotypes,
-            "samples": samples,
-            "sample_data": sample_data,
-            "locs": locs,
-            "config": locator.config,
-            "known_idx": known_idx,
-        }
-    )
-
-    if verbose:
-        print(f"Running {n_reps} holdout replicates across GPUs {gpu_ids} using Ray...")
-
-    start_time = time.time()
-
-    _ray_holdout_worker = _create_ray_holdout_worker(gpu_fraction)
-
-    # Submit all replicates to Ray
-    futures = []
-    for rep_idx in range(n_reps):
-        if len(gpu_ids) == 0:
-            gpu_id = -1
-        else:
-            gpu_id = gpu_ids[rep_idx % len(gpu_ids)]
-
-        future = _ray_holdout_worker.remote(
-            rep_idx=rep_idx,
-            gpu_id=gpu_id,
-            data=data_ref,
-            holdout_indices=all_holdout_indices[rep_idx],
-        )
-        futures.append(future)
-        if verbose:
-            device_str = "CPU" if gpu_id == -1 else f"GPU {gpu_id}"
-            print(f"Submitted replicate {rep_idx} to {device_str}")
-
-    # Wait for all replicates to complete
-    results = _collect_ray_results(
-        futures,
-        desc="Replicates completed",
-        postfix_fn=lambda r: f"Last: Rep {r['rep']}, GPU {r['gpu_id']}",
-        verbose=verbose,
-    )
-
-    total_time = time.time() - start_time
-
-    if verbose:
+    chunk_path = _holdout_chunk_path(locator)
+    done_reps = _resume_completed_reps(chunk_path) if resume else set()
+    if done_reps and verbose:
         print(
-            f"\nCompleted {n_reps} replicates in "
-            f"{total_time:.1f}s "
-            f"({total_time / n_reps:.1f}s per replicate)"
+            f"Resume: {len(done_reps)} / {n_reps} replicates already present in "
+            f"{chunk_path}; skipping those."
         )
+
+    reps_to_run = [i for i in range(n_reps) if i not in done_reps]
+
+    if reps_to_run:
+        data_ref = ray.put(
+            {
+                "filtered_genotypes": filtered_genotypes,
+                "samples": samples,
+                "sample_data": sample_data,
+                "locs": locs,
+                "config": locator.config,
+                "known_idx": known_idx,
+            }
+        )
+
+        actors = make_fold_workers(
+            gpu_ids=gpu_ids,
+            gpu_fraction=gpu_fraction,
+            data_ref=data_ref,
+            gpu_mem_mb=gpu_mem_mb,
+        )
+        if verbose:
+            print(
+                f"Spawned {len(actors)} FoldWorker actors across GPUs {gpu_ids}; "
+                f"dispatching {len(reps_to_run)} replicates "
+                f"(gpu_fraction={gpu_fraction})."
+            )
+
+        pool = ActorPool(actors)
+        rep_args = [(i, all_holdout_indices[i]) for i in reps_to_run]
+
+        pbar = None
+        if verbose:
+            try:
+                from tqdm import tqdm
+
+                pbar = tqdm(total=len(reps_to_run), desc="Replicates")
+            except ImportError:
+                pass
+
+        start_time = time.time()
+        completed = 0
+        for result in pool.map_unordered(
+            lambda actor, args: actor.run_holdout.remote(args[0], args[1]),
+            rep_args,
+        ):
+            _append_rep_to_chunks(chunk_path, result["idx"], result["rows"])
+            completed += 1
+            if pbar is not None:
+                pbar.update(1)
+
+        if pbar is not None:
+            pbar.close()
+
+        total_time = time.time() - start_time
+        if verbose:
+            per_rep = total_time / max(completed, 1)
+            print(
+                f"\nCompleted {completed} replicates in {total_time:.1f}s "
+                f"({per_rep:.1f}s per replicate)."
+            )
+
+        for actor in actors:
+            ray.kill(actor)
+    else:
+        if verbose:
+            print("All replicates already complete.")
 
     _restore_bandwidth(locator, bw_calculated, bw_original)
 
-    if return_df:
-        pred_dfs = []
+    if not return_df:
+        return None
 
-        for result in results:
-            rep_idx = result["rep"]
-            predictions = pd.DataFrame(result["predictions"])
+    # Pivot the long-format chunks to the wide-format output contract.
+    chunks = pd.read_csv(chunk_path)
+    wide = chunks.pivot_table(
+        index="sampleID", columns="rep", values=["x_pred", "y_pred"], aggfunc="first"
+    )
+    wide.columns = [
+        f"{val}_rep{rep}".replace("x_pred", "x").replace("y_pred", "y")
+        for val, rep in wide.columns
+    ]
+    wide = wide.reset_index()
 
-            holdout_preds = predictions[["x_pred", "y_pred"]].copy()
-            holdout_preds.columns = [
-                f"x_rep{rep_idx}",
-                f"y_rep{rep_idx}",
-            ]
-            holdout_preds["sampleID"] = predictions["sampleID"]
-            pred_dfs.append(holdout_preds)
+    if save_full_pred_matrix:
+        wide.to_csv(_holdout_output_path(locator), index=False)
 
-        all_predictions = pred_dfs[0]
-        for df in pred_dfs[1:]:
-            all_predictions = pd.merge(all_predictions, df, on="sampleID", how="outer")
-
-        if save_full_pred_matrix:
-            all_predictions.to_csv(
-                f"{locator.config['out']}_holdouts_predlocs.csv",
-                index=False,
-            )
-
-        return all_predictions
-
-    return None
+    return wide

--- a/locator/parallel/kfold.py
+++ b/locator/parallel/kfold.py
@@ -1,123 +1,59 @@
-"""K-fold cross-validation parallel methods."""
+"""K-fold cross-validation parallel methods.
 
+This module dispatches folds across a pool of long-lived Ray actors
+(``FoldWorker``) rather than fresh Ray tasks. The actor approach keeps the
+TF runtime + autograph + XLA caches hot across folds, eliminating the
+multi-second cold-start tax that dominated wall time in LOO sweeps.
+
+The dispatcher also writes per-fold predictions to disk as they complete,
+so a kill/crash mid-sweep doesn't discard already-trained folds — re-running
+with ``resume=True`` (default) picks up where the previous run left off.
+"""
+
+from __future__ import annotations
+
+import os
 import time
-from typing import Any, Dict, List, Optional, Union
+from typing import List, Optional, Union
 
 import numpy as np
 import pandas as pd
 import ray
+from ray.util import ActorPool
 
+from ._actor import DEFAULT_GPU_MEM_MB, make_fold_workers
 from ._helpers import (
-    _collect_ray_results,
-    _create_worker_locator,
     _ensure_ray_initialized,
     _precalculate_bandwidth,
     _restore_bandwidth,
-    _setup_worker_env,
 )
 
 
-def _create_ray_kfold_worker(gpu_fraction: float = 1.0):
-    """
-    Factory function to create a Ray worker with specified GPU fraction.
+def _kfold_output_path(locator) -> str:
+    return f"{locator.config['out']}_kfold_holdouts_predlocs.csv"
 
-    Args:
-        gpu_fraction: Fraction of GPU to allocate per worker (value between 0.0 to 1.0)
-                     1.0 = one full GPU per worker (default)
-                     0.5 = two workers can share one GPU
-                     0.25 = four workers can share one GPU
-                     ...
-                     0.0 = CPU only
 
-    Returns
-    -------
-        Ray remote function configured with specified GPU fraction
-    """
+def _resume_completed_folds(output_path: str) -> set[int]:
+    """Return the set of fold indices already present in ``output_path``."""
+    if not os.path.exists(output_path):
+        return set()
+    try:
+        existing = pd.read_csv(output_path)
+    except (pd.errors.EmptyDataError, FileNotFoundError):
+        return set()
+    if existing.empty or "fold" not in existing.columns:
+        return set()
+    return set(existing["fold"].astype(int).tolist())
 
-    @ray.remote(num_gpus=gpu_fraction)
-    def _ray_kfold_worker(fold_idx: int, gpu_id: int, data: dict) -> Dict[str, Any]:
-        """
-        Ray worker function that runs a single k-fold on a specific GPU.
 
-        Args:
-            fold_idx: Fold index
-            gpu_id: GPU ID to use
-            data: Shared data dict (resolved from Ray object store)
-
-        Returns
-        -------
-            Dictionary with predictions and metadata
-        """
-        _setup_worker_env(gpu_id)
-
-        import allel
-        import tensorflow as tf
-
-        tf.get_logger().setLevel("ERROR")
-
-        print(f"Worker processing fold {fold_idx} on GPU {gpu_id}")
-
-        locator = _create_worker_locator(data, f"fold{fold_idx}")
-
-        # Get fold's IndexSet
-        index_set = data["fold_index_sets"][fold_idx]
-        holdout_indices = index_set.test
-
-        # Use pre-filtered allele counts if available, avoiding the
-        # expensive per-worker copy of the full genotype array.
-        filtered = data.get("filtered_genotypes")
-        if filtered is not None:
-            genotypes = None
-        elif "genotypes_array" in data:
-            genotypes = allel.GenotypeArray(data["genotypes_array"])
-        else:
-            raise ValueError("Worker received neither filtered nor raw genotypes")
-
-        # Train with holdout
-        start_time = time.time()
-        history = locator.train_holdout(
-            genotypes=genotypes,
-            samples=data["samples"],
-            holdout_indices=holdout_indices,
-            filtered_genotypes=filtered,
-        )
-        train_time = time.time() - start_time
-
-        # Make predictions
-        predictions = locator.predict_holdout(
-            verbose=False,
-            return_df=True,
-            save_preds_to_disk=False,
-            plot_summary=False,
-            plot_map=False,
-        )
-
-        # Verify sample IDs match expected holdout samples
-        expected_samples = [data["samples"][i] for i in holdout_indices]
-        actual_samples = predictions["sampleID"].tolist()
-
-        if set(expected_samples) != set(actual_samples):
-            print(f"WARNING: Sample mismatch in fold {fold_idx}!")
-            print(f"Expected {len(expected_samples)} samples, got {len(actual_samples)}")
-            print(f"First 5 expected: {expected_samples[:5]}")
-            print(f"First 5 actual: {actual_samples[:5]}")
-
-        tf.keras.backend.clear_session()
-
-        return {
-            "fold": fold_idx,
-            "gpu_id": gpu_id,
-            "train_time": train_time,
-            "predictions": predictions.to_dict("records"),
-            "holdout_indices": holdout_indices.tolist(),
-            "final_loss": (
-                float(history.history["loss"][-1])
-                if history and "loss" in history.history
-                else None
-            ),
-        }
-
-    return _ray_kfold_worker
+def _append_fold_to_csv(output_path: str, fold: int, rows: list) -> None:
+    """Append one fold's predictions to the running CSV, with header on first write."""
+    write_header = not os.path.exists(output_path) or os.path.getsize(output_path) == 0
+    with open(output_path, "a") as f:
+        if write_header:
+            f.write("sampleID,x_pred,y_pred,fold\n")
+        for r in rows:
+            f.write(f"{r['sampleID']},{r['x_pred']},{r['y_pred']},{fold}\n")
 
 
 def parallel_k_fold_holdouts(  # noqa: C901
@@ -131,97 +67,97 @@ def parallel_k_fold_holdouts(  # noqa: C901
     save_full_pred_matrix: bool = True,
     verbose: bool = True,
     na_action: Optional[str] = None,
+    resume: bool = True,
+    gpu_mem_mb: int = DEFAULT_GPU_MEM_MB,
 ) -> Union[pd.DataFrame, None]:
-    """
-    Run true k-fold cross-validation in parallel across multiple GPUs using Ray.
-
-    This is a parallel version of AnalysisMixin.run_k_fold_holdouts() that distributes
-    folds across available GPUs.
+    """Run true k-fold cross-validation across multiple GPUs via Ray actors.
 
     Args:
-        locator: Locator instance (for configuration and methods)
-        genotypes: GenotypeArray
-        samples: List of sample IDs
-        k: Number of folds (holdout sets)
-        gpu_ids: List of GPU IDs to use
-        gpu_fraction: Fraction of GPU to allocate per worker (default 1.0)
-            - 1.0: One full GPU per worker (safest, no GPU sharing)
-            - 0.5: Two workers can share one GPU
-            - 0.25: Four workers can share one GPU
-            - 0.0: CPU only execution
-        return_df: Whether to return DataFrame with all predictions
-        save_full_pred_matrix: Whether to save full prediction matrix to disk
-        verbose: Whether to show training progress and intermediate output
-        na_action: How to handle NA samples ('separate', 'exclude', 'fail').
-            If None, uses locator.na_action
+        locator: Locator instance (config + helper methods).
+        genotypes: GenotypeArray (or pre-filtered dosage matrix).
+        samples: Sample IDs corresponding to genotypes.
+        k: Number of folds.
+        gpu_ids: List of GPU IDs to dispatch across.
+        gpu_fraction: Fraction of one GPU reserved per actor. ``1.0`` is one
+            actor per GPU; ``0.5`` packs two actors per GPU; ``0.0`` runs CPU
+            only. The actor also caps TF GPU memory at this fraction so
+            co-tenants can't OOM each other.
+        return_df: Return aggregated DataFrame at the end.
+        save_full_pred_matrix: Write the aggregated CSV at the end (the
+            running per-fold CSV is always written regardless).
+        verbose: Print progress + per-fold timing.
+        na_action: ``'separate' | 'exclude' | 'fail'``; defaults to locator's.
+        resume: Skip folds already present in the on-disk CSV.
+        gpu_mem_mb: Total GPU memory in MB used to compute the per-actor cap.
+            Default 80GB matches A100; override for other devices.
 
     Returns
     -------
-        pandas.DataFrame or None: If return_df=True, returns DataFrame with one prediction
-            per held-out sample containing columns:
-            - sampleID: Sample identifier
-            - x_pred: Predicted longitude
-            - y_pred: Predicted latitude
-            - fold: Fold number (0 to k-1)
-
-            Note: True locations are not included. To calculate prediction errors, merge
-            the returned DataFrame with your sample metadata using the sampleID column.
+        DataFrame with columns ``[sampleID, x_pred, y_pred, fold]`` (or
+        ``None`` if ``return_df=False``).
     """
     _ensure_ray_initialized()
 
-    na_action, status = locator._validate_na_action(samples, na_action, "K-fold CV")
+    na_action, _ = locator._validate_na_action(samples, na_action, "K-fold CV")
 
     sample_data, locs = locator._resolve_locations(samples)
-
-    # Create NA mask
     na_mask = np.isnan(locs[:, 0])
     n_total_samples = len(locs)
-    n_samples_with_coords = np.sum(~na_mask)
+    n_with_coords = int(np.sum(~na_mask))
 
-    if k > n_samples_with_coords:
+    if k > n_with_coords:
         raise ValueError(
-            f"k ({k}) must be less than or equal to number of "
-            f"samples with known locations "
-            f"({n_samples_with_coords})"
+            f"k ({k}) must be <= number of samples with known locations "
+            f"({n_with_coords})"
         )
 
-    # Import IndexSet
     from locator.data.indexset import IndexSet
 
-    # Create list to store IndexSets for each fold
-    # Use a fixed seed based on config seed or numpy's current state
     if "seed" in locator.config and locator.config["seed"] is not None:
         kfold_seed = locator.config["seed"]
     else:
         kfold_seed = np.random.randint(0, 2**31)
 
-    fold_index_sets = []
-    for fold_idx in range(k):
-        index_set = IndexSet.from_k_fold(
+    fold_index_sets = [
+        IndexSet.from_k_fold(
             n=n_total_samples,
             k=k,
-            fold=fold_idx,
+            fold=i,
             seed=kfold_seed,
             na_mask=na_mask,
         )
-        fold_index_sets.append(index_set)
+        for i in range(k)
+    ]
 
-    # Pre-calculate KDE bandwidth if needed
-    bw_locs = locs[~na_mask]
     bw_calculated, bw_original = _precalculate_bandwidth(
         locator,
-        bw_locs,
-        f"kfold_k{k}_n{len(bw_locs)}",
+        locs[~na_mask],
+        f"kfold_k{k}_n{n_with_coords}",
         verbose,
     )
 
-    # Pre-filter once so workers share a small array instead of the full genotypes
     filtered_genotypes = locator._filter_genotypes(genotypes)
     if verbose:
         print(
             f"Pre-filtered genotypes: {genotypes.shape[0]:,} → "
             f"{filtered_genotypes.shape[0]:,} SNPs"
         )
+
+    output_path = _kfold_output_path(locator)
+    done_folds = _resume_completed_folds(output_path) if resume else set()
+    if done_folds and verbose:
+        print(
+            f"Resume: {len(done_folds)} / {k} folds already present in "
+            f"{output_path}; skipping those."
+        )
+
+    folds_to_run = [i for i in range(k) if i not in done_folds]
+
+    if not folds_to_run:
+        if verbose:
+            print("All folds already complete.")
+        _restore_bandwidth(locator, bw_calculated, bw_original)
+        return pd.read_csv(output_path) if return_df else None
 
     data_ref = ray.put(
         {
@@ -230,95 +166,84 @@ def parallel_k_fold_holdouts(  # noqa: C901
             "sample_data": sample_data,
             "locs": locs,
             "config": locator.config,
-            "fold_index_sets": fold_index_sets,
             "na_mask": na_mask,
         }
     )
 
+    actors = make_fold_workers(
+        gpu_ids=gpu_ids,
+        gpu_fraction=gpu_fraction,
+        data_ref=data_ref,
+        gpu_mem_mb=gpu_mem_mb,
+    )
     if verbose:
         print(
-            f"Running true {k}-fold cross-validation across GPUs {gpu_ids} using Ray..."
+            f"Spawned {len(actors)} FoldWorker actors across GPUs {gpu_ids}; "
+            f"dispatching {len(folds_to_run)} folds (gpu_fraction={gpu_fraction})."
         )
 
+    pool = ActorPool(actors)
+    fold_args = [(i, fold_index_sets[i].test.tolist()) for i in folds_to_run]
     start_time = time.time()
 
-    # Create the Ray worker with specified GPU fraction
-    _ray_kfold_worker = _create_ray_kfold_worker(gpu_fraction)
+    pbar = None
+    if verbose:
+        try:
+            from tqdm import tqdm
 
-    # Submit all folds to Ray
-    futures = []
-    for fold_idx in range(k):
-        if len(gpu_ids) == 0:
-            gpu_id = -1
-        else:
-            gpu_id = gpu_ids[fold_idx % len(gpu_ids)]
+            pbar = tqdm(total=len(folds_to_run), desc="Folds")
+        except ImportError:
+            pass
 
-        future = _ray_kfold_worker.remote(
-            fold_idx=fold_idx, gpu_id=gpu_id, data=data_ref
-        )
-        futures.append(future)
-        if verbose:
-            device_str = "CPU" if gpu_id == -1 else f"GPU {gpu_id}"
-            print(f"Submitted fold {fold_idx} to {device_str}")
+    completed = 0
+    for result in pool.map_unordered(
+        lambda actor, args: actor.run_fold.remote(args[0], args[1]),
+        fold_args,
+    ):
+        _append_fold_to_csv(output_path, result["fold"], result["rows"])
+        completed += 1
+        if pbar is not None:
+            pbar.update(1)
 
-    # Wait for all folds to complete
-    results = _collect_ray_results(
-        futures,
-        desc="Folds completed",
-        postfix_fn=lambda r: f"Last: Fold {r['fold']}, GPU {r['gpu_id']}",
-        verbose=verbose,
-    )
+    if pbar is not None:
+        pbar.close()
 
     total_time = time.time() - start_time
-
     if verbose:
+        per_fold = total_time / max(completed, 1)
         print(
-            f"\nCompleted {k}-fold CV in {total_time:.1f}s "
-            f"({total_time / k:.1f}s per fold)"
+            f"\nCompleted {completed} folds in {total_time:.1f}s "
+            f"({per_fold:.1f}s per fold)."
         )
 
     _restore_bandwidth(locator, bw_calculated, bw_original)
 
-    if return_df:
-        # Build predictions DataFrame
-        pred_rows = []
-        for result in results:
-            for pred in result["predictions"]:
-                pred_rows.append(
-                    {
-                        "sampleID": pred["sampleID"],
-                        "x_pred": pred["x_pred"],
-                        "y_pred": pred["y_pred"],
-                        "fold": result["fold"],
-                    }
-                )
+    # Kill actors so the TF GPU memory is released before the caller returns.
+    for actor in actors:
+        ray.kill(actor)
 
-        all_predictions = pd.DataFrame(pred_rows)
+    df = pd.read_csv(output_path)
 
-        # Verify we have predictions for all expected samples
-        expected_samples = set(samples[i] for i in range(len(samples)) if not na_mask[i])
-        actual_samples = set(all_predictions["sampleID"].unique())
-
-        if expected_samples != actual_samples:
-            print("WARNING: Sample mismatch in final results!")
-            print(f"Expected {len(expected_samples)} unique samples")
-            print(f"Got {len(actual_samples)} unique samples")
-            missing = expected_samples - actual_samples
-            extra = actual_samples - expected_samples
-            if missing:
-                print("Missing samples: {list(missing)[:10]}...")
-            if extra:
-                print(f"Extra samples: {list(extra)[:10]}...")
-
-        if save_full_pred_matrix:
-            all_predictions.to_csv(
-                f"{locator.config['out']}_kfold_holdouts_predlocs.csv",
-                index=False,
+    expected = {samples[i] for i in range(len(samples)) if not na_mask[i]}
+    actual = set(df["sampleID"].unique())
+    missing = expected - actual
+    extra = actual - expected
+    if missing or extra:
+        print("WARNING: Sample mismatch in final results!")
+        print(f"  expected {len(expected)} unique samples, got {len(actual)}")
+        if missing:
+            print(
+                f"  missing: {sorted(missing)[:10]}{'...' if len(missing) > 10 else ''}"
             )
+        if extra:
+            print(f"  extra:   {sorted(extra)[:10]}{'...' if len(extra) > 10 else ''}")
 
-        return all_predictions
+    if not save_full_pred_matrix:
+        # The on-disk CSV is the per-fold checkpoint; if the caller doesn't
+        # want a final aggregate the file still exists. Nothing else to do.
+        pass
 
-    return None
+    return df if return_df else None
 
 
 def parallel_leave_one_out(
@@ -330,58 +255,46 @@ def parallel_leave_one_out(
     return_df: bool = True,
     save_full_pred_matrix: bool = True,
     na_action: Optional[str] = None,
+    resume: bool = True,
+    gpu_mem_mb: int = DEFAULT_GPU_MEM_MB,
 ) -> Union[pd.DataFrame, None]:
+    """Leave-one-out cross-validation via the k-fold dispatcher.
+
+    Equivalent to ``parallel_k_fold_holdouts`` with ``k = n_samples_with_coords``.
+    Writes to ``{out}_leave_one_out_predlocs.csv`` instead of the k-fold path
+    so partial LOO and k-fold runs against the same Locator output prefix
+    don't collide.
     """
-    Perform leave-one-out cross-validation in parallel across multiple GPUs.
-
-    This is a parallel version of AnalysisMixin.run_leave_one_out() that uses
-    Ray to distribute the computation. It's a convenience wrapper around
-    parallel_k_fold_holdouts with k equal to the number of samples with known locations.
-
-    Args:
-        locator: Locator instance (for configuration and methods)
-        genotypes: Array of genotype data
-        samples: Sample IDs corresponding to genotypes
-        gpu_ids: List of GPU IDs to use
-        gpu_fraction: Fraction of GPU to allocate per worker (default 1.0)
-        return_df: Whether to return DataFrame with all predictions
-        save_full_pred_matrix: Whether to save full prediction matrix to disk
-        na_action: How to handle NA samples ('separate', 'exclude', 'fail').
-            If None, uses locator.na_action
-
-    Returns
-    -------
-        pandas.DataFrame or None: DataFrame with predictions for each left-out sample
-    """
-    # Get sample status to determine k
     status = locator.get_sample_status(samples)
     n_known = status["n_known"]
-
     if n_known == 0:
         raise ValueError("No samples with known coordinates for leave-one-out CV")
 
-    print(
-        f"Running leave-one-out cross-validation for "
-        f"{n_known} samples across GPUs {gpu_ids}"
-    )
-
-    result = parallel_k_fold_holdouts(
-        locator=locator,
-        genotypes=genotypes,
-        samples=samples,
-        k=n_known,
-        gpu_ids=gpu_ids,
-        gpu_fraction=gpu_fraction,
-        return_df=return_df,
-        save_full_pred_matrix=False,
-        verbose=False,
-        na_action=na_action,
-    )
-
-    if result is not None and save_full_pred_matrix:
-        result.to_csv(
-            f"{locator.config['out']}_leave_one_out_predlocs.csv",
-            index=False,
+    # Route LOO results through a dedicated checkpoint path. We temporarily
+    # patch the Locator's ``out`` prefix so the k-fold helper writes to the
+    # LOO file; this avoids replicating the dispatcher logic.
+    original_out = locator.config["out"]
+    locator.config["out"] = original_out + "__loo"
+    try:
+        df = parallel_k_fold_holdouts(
+            locator=locator,
+            genotypes=genotypes,
+            samples=samples,
+            k=n_known,
+            gpu_ids=gpu_ids,
+            gpu_fraction=gpu_fraction,
+            return_df=return_df,
+            save_full_pred_matrix=False,
+            verbose=True,
+            na_action=na_action,
+            resume=resume,
+            gpu_mem_mb=gpu_mem_mb,
         )
+    finally:
+        locator.config["out"] = original_out
 
-    return result
+    if df is not None and save_full_pred_matrix:
+        loo_path = f"{original_out}_leave_one_out_predlocs.csv"
+        df.to_csv(loo_path, index=False)
+
+    return df

--- a/locator/parallel/kfold.py
+++ b/locator/parallel/kfold.py
@@ -197,10 +197,10 @@ def parallel_k_fold_holdouts(  # noqa: C901
 
     completed = 0
     for result in pool.map_unordered(
-        lambda actor, args: actor.run_fold.remote(args[0], args[1]),
+        lambda actor, args: actor.run_holdout.remote(args[0], args[1]),
         fold_args,
     ):
-        _append_fold_to_csv(output_path, result["fold"], result["rows"])
+        _append_fold_to_csv(output_path, result["idx"], result["rows"])
         completed += 1
         if pbar is not None:
             pbar.update(1)

--- a/locator/parallel/windowed.py
+++ b/locator/parallel/windowed.py
@@ -1,147 +1,145 @@
-"""Windowed holdout analysis parallel methods."""
+"""Windowed holdout-analysis parallel methods.
 
+Each window trains a model on a different slice of SNP indices but shares
+the same train/holdout sample split. The full genotype array is materialised
+once on each ``WindowActor`` at startup; per-window calls only ship the SNP
+index list. Predictions are streamed to a long-format checkpoint as windows
+complete and pivoted to the wide-format output (``x_<label>``, ``y_<label>``)
+at the end. ``resume=True`` (default) skips windows already present in the
+checkpoint.
+"""
+
+from __future__ import annotations
+
+import os
 import time
 from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
 import pandas as pd
 import ray
+from ray.util import ActorPool
 
+from ._actor import DEFAULT_GPU_MEM_MB, make_window_actors
 from ._helpers import (
-    _collect_ray_results,
-    _create_worker_locator,
     _ensure_ray_initialized,
     _precalculate_bandwidth,
     _restore_bandwidth,
-    _setup_worker_env,
 )
 
 
-def _create_ray_windows_worker(gpu_fraction: float = 1.0):
-    """
-    Factory function to create a Ray worker for windowed holdout analysis.
+def _windows_chunk_path(locator) -> str:
+    return f"{locator.config['out']}_windows_chunks.csv"
 
-    Args:
-        gpu_fraction: Fraction of GPU to allocate per worker
 
-    Returns
-    -------
-        Ray remote function configured with specified GPU fraction
-    """
+def _windows_output_path(locator) -> str:
+    return f"{locator.config['out']}_windows_holdouts_predlocs.csv"
 
-    @ray.remote(num_gpus=gpu_fraction)
-    def _ray_windows_worker(
-        window_idx: int,
-        window_start: int,
-        window_stop: int,
-        gpu_id: int,
-        data: dict,
-    ) -> Dict[str, Any]:
-        """
-        Ray worker function that runs holdout analysis for a single genomic window.
 
-        Args:
-            window_idx: Window index
-            window_start: Start position of window
-            window_stop: Stop position of window
-            gpu_id: GPU ID to use
-            data: Shared data dict (resolved from Ray object store)
+def _resume_completed_windows(chunk_path: str) -> set[str]:
+    if not os.path.exists(chunk_path):
+        return set()
+    try:
+        existing = pd.read_csv(chunk_path)
+    except (pd.errors.EmptyDataError, FileNotFoundError):
+        return set()
+    if existing.empty or "window_label" not in existing.columns:
+        return set()
+    return set(existing["window_label"].astype(str).tolist())
 
-        Returns
-        -------
-            Dictionary with predictions and metadata
-        """
-        _setup_worker_env(gpu_id)
 
+def _append_window_to_chunks(chunk_path: str, label: str, rows: list) -> None:
+    write_header = not os.path.exists(chunk_path) or os.path.getsize(chunk_path) == 0
+    with open(chunk_path, "a") as f:
+        if write_header:
+            f.write("sampleID,x_pred,y_pred,window_label\n")
+        for r in rows:
+            f.write(f"{r['sampleID']},{r['x_pred']},{r['y_pred']},{label}\n")
+
+
+def _load_positions(locator, verbose: bool) -> None:
+    """Populate locator.positions (and .chromosomes when available)."""
+    if hasattr(locator, "positions") and locator.positions is not None:
+        return
+    if hasattr(locator, "_genotype_df"):
+        locator.positions = np.array(locator._genotype_df.columns, dtype=int)
+        return
+    if locator.config.get("zarr"):
+        import zarr
+
+        callset = zarr.open_group(locator.config["zarr"], mode="r")
+        locator.positions = callset["variants/POS"][:]
+        return
+    if locator.config.get("vcf"):
+        if verbose:
+            print("Loading SNP positions from VCF...")
         import allel
-        import tensorflow as tf
 
-        from locator.data.filters import normalize_locs  # noqa: F401
-        from locator.data.indexset import IndexSet  # noqa: F401
+        vcf = allel.read_vcf(locator.config["vcf"], fields=["POS", "CHROM"])
+        if vcf is None or "variants/POS" not in vcf:
+            raise ValueError(
+                f"Could not load positions from VCF: {locator.config['vcf']}"
+            )
+        locator.positions = vcf["variants/POS"]
+        if "variants/CHROM" in vcf:
+            locator.chromosomes = vcf["variants/CHROM"]
+        if verbose:
+            print(f"Loaded {len(locator.positions)} SNP positions")
+        return
+    raise ValueError(
+        "SNP positions required for windowed analysis. Use VCF, zarr input "
+        "or genotype DataFrame with position-labeled columns."
+    )
 
-        tf.get_logger().setLevel("ERROR")
 
-        print(
-            f"Worker processing window {window_idx} "
-            f"({window_start}-{window_stop}) on GPU {gpu_id}"
+def _resolve_train_test_split(
+    locator,
+    samples,
+    locs,
+    na_mask,
+    na_action,
+    holdout_indices,
+    holdout_sample_ids,
+    k,
+):
+    """Build the shared IndexSet used for every window's train/test split."""
+    from locator.data.indexset import IndexSet
+
+    n_samples = len(samples)
+
+    if holdout_sample_ids is not None:
+        samples_list = samples.tolist() if hasattr(samples, "tolist") else list(samples)
+        try:
+            holdout_indices = [samples_list.index(sid) for sid in holdout_sample_ids]
+        except ValueError:
+            missing = [sid for sid in holdout_sample_ids if sid not in samples_list]
+            raise ValueError(f"Sample IDs not found in samples list: {missing}")
+        k = len(holdout_indices)
+
+    if holdout_indices is not None:
+        holdout_idx = np.array(holdout_indices)
+        train_mask = np.ones(n_samples, dtype=bool)
+        train_mask[holdout_idx] = False
+        train_idx = np.where(train_mask)[0]
+
+        if na_mask is not None and na_action in {"exclude", "separate"}:
+            valid_mask = ~na_mask
+            holdout_idx = holdout_idx[valid_mask[holdout_idx]]
+            train_idx = train_idx[valid_mask[train_idx]]
+
+        return IndexSet(
+            indices={"train": train_idx, "test": holdout_idx},
+            total_samples=n_samples,
+            na_mask=na_mask,
         )
 
-        genotypes = allel.GenotypeArray(data["genotypes_array"])
-
-        # Get window specification
-        windows = data.get("windows", [])
-        if window_idx < len(windows):
-            window_spec = windows[window_idx]
-            snp_indices = np.where(window_spec["indices"])[0]
-            window_label = window_spec["label"]
-            window_chromosome = window_spec.get("chromosome")
-        else:
-            positions = data["positions"]
-            snp_mask = (positions >= window_start) & (positions < window_stop)
-            snp_indices = np.where(snp_mask)[0]
-            window_label = f"pos{window_start}"
-            window_chromosome = None
-
-        if len(snp_indices) == 0:
-            print(f"No SNPs in window {window_start}-{window_stop}")
-            return {
-                "window_idx": window_idx,
-                "window_start": window_start,
-                "window_stop": window_stop,
-                "window_label": window_label,
-                "window_chromosome": window_chromosome,
-                "predictions": None,
-                "n_snps": 0,
-            }
-
-        locator = _create_worker_locator(data, f"win{window_idx}")
-        locator.genotypes = genotypes
-        locator.index_set = data["index_set"]
-
-        # Set normalization parameters
-        locator.meanlong = data["meanlong"]
-        locator.sdlong = data["sdlong"]
-        locator.meanlat = data["meanlat"]
-        locator.sdlat = data["sdlat"]
-        locator.unnormedlocs = data["unnormedlocs"]
-
-        # Train on window
-        start_time = time.time()
-        locator.train_window(
-            genotypes=genotypes,
-            samples=data["samples"],
-            window_snp_indices=snp_indices,
-            index_set=data["index_set"],
-            normalized_locs=data["normalized_locs"],
-        )
-        train_time = time.time() - start_time
-
-        # Make predictions
-        predictions = locator.predict_holdout(
-            verbose=False,
-            return_df=True,
-            save_preds_to_disk=False,
-            plot_summary=False,
-            plot_map=False,
-        )
-
-        tf.keras.backend.clear_session()
-
-        return {
-            "window_idx": window_idx,
-            "window_start": window_start,
-            "window_stop": window_stop,
-            "window_label": window_label,
-            "window_chromosome": window_chromosome,
-            "gpu_id": gpu_id,
-            "train_time": train_time,
-            "predictions": (
-                predictions.to_dict("records") if predictions is not None else None
-            ),
-            "n_snps": len(snp_indices),
-        }
-
-    return _ray_windows_worker
+    return IndexSet.random_split(
+        n=n_samples,
+        splits={"train": 1.0 - k / n_samples, "test": k / n_samples},
+        seed=locator.config.get("seed", 42),
+        na_mask=na_mask,
+        na_action=(na_action if na_action != "separate" else "exclude"),
+    )
 
 
 def parallel_windows_holdouts(  # noqa: C901
@@ -161,155 +159,40 @@ def parallel_windows_holdouts(  # noqa: C901
     save_full_pred_matrix: bool = True,
     verbose: bool = True,
     na_action: Optional[str] = None,
+    resume: bool = True,
+    gpu_mem_mb: int = DEFAULT_GPU_MEM_MB,
 ) -> Union[pd.DataFrame, None]:
-    """
-    Run windowed analysis on holdout samples in parallel across multiple GPUs using Ray.
-
-    This is a parallel version of AnalysisMixin.run_windows_holdouts() that distributes
-    windows across available GPUs.
-
-    Args:
-        locator: Locator instance (for configuration and methods)
-        genotypes: GenotypeArray
-        samples: List of sample IDs
-        k: Number of samples to hold out
-        window_start: Start position for windows
-        window_size: Size of windows in base pairs
-        window_stop: Stop position for windows (if None, uses max position)
-        respect_chromosomes: Whether to respect chromosome boundaries when creating
-            windows (default: True). If True, windows will not span chromosome
-            boundaries. Requires chromosome information from VCF/Zarr input.
-        holdout_indices: Optional specific indices to hold out
-        holdout_sample_ids: Optional list of sample IDs to hold out. If provided,
-            these specific samples will be held out (overrides k and holdout_indices).
-        gpu_ids: List of GPU IDs to use
-        gpu_fraction: Fraction of GPU to allocate per worker (default 1.0)
-        return_df: Whether to return DataFrame with all predictions
-        save_full_pred_matrix: Whether to save full prediction matrix to disk
-        verbose: Whether to show training progress and intermediate output
-        na_action: How to handle NA samples ('separate', 'exclude', 'fail').
-            If None, uses locator.na_action
-
-    Returns
-    -------
-        pandas.DataFrame or None: If return_df=True, returns DataFrame with predictions
-            for each window containing columns:
-            - sampleID: Sample identifier
-            - x_pos0, y_pos0: Predictions from window starting at position 0
-            - x_pos500000, y_pos500000: Predictions from window starting at position 500000
-            - ... and so on for all windows
-
-            Note: True locations are not included. Merge with sample metadata to calculate errors.
-
-    Warning:
-        When respect_chromosomes=False, window analysis treats all SNP positions as
-        continuous along a single coordinate axis. If your data contains multiple
-        chromosomes, windows may span across chromosome boundaries. Use
-        respect_chromosomes=True (default) for biologically meaningful windows.
-    """
+    """Run windowed holdout analysis across multiple GPUs via a ``WindowActor`` pool."""
     _ensure_ray_initialized()
 
-    # Store samples and genotypes
     locator.samples = samples
     locator.genotypes = genotypes
 
-    na_action, status = locator._validate_na_action(
+    na_action, _ = locator._validate_na_action(
         samples, na_action, "Windows holdout analysis"
     )
 
-    # Get positions
-    if not hasattr(locator, "positions") or locator.positions is None:
-        if hasattr(locator, "_genotype_df"):
-            locator.positions = np.array(locator._genotype_df.columns, dtype=int)
-        elif locator.config.get("zarr"):
-            import zarr
-
-            callset = zarr.open_group(locator.config["zarr"], mode="r")
-            locator.positions = callset["variants/POS"][:]
-        elif locator.config.get("vcf"):
-            if verbose:
-                print("Loading SNP positions from VCF...")
-            import allel
-
-            vcf = allel.read_vcf(
-                locator.config["vcf"],
-                fields=["POS", "CHROM"],
-            )
-            if vcf is not None and "variants/POS" in vcf:
-                locator.positions = vcf["variants/POS"]
-                if "variants/CHROM" in vcf:
-                    locator.chromosomes = vcf["variants/CHROM"]
-                if verbose:
-                    print(f"Loaded {len(locator.positions)} SNP positions")
-            else:
-                raise ValueError(
-                    f"Could not load positions from VCF: {locator.config['vcf']}"
-                )
-        else:
-            raise ValueError(
-                "SNP positions required for windowed analysis. "
-                "Use VCF, zarr input or genotype DataFrame "
-                "with position-labeled columns."
-            )
+    _load_positions(locator, verbose)
 
     sample_data, locs = locator._resolve_locations(samples)
-
-    # Derive NA mask from resolved locations
     na_mask = np.isnan(locs[:, 0])
     if not na_mask.any():
         na_mask = None
 
-    # Handle holdout_sample_ids if provided
-    if holdout_sample_ids is not None:
-        if hasattr(samples, "tolist"):
-            samples_list = samples.tolist()
-        else:
-            samples_list = list(samples)
-
-        try:
-            holdout_indices = [samples_list.index(sid) for sid in holdout_sample_ids]
-        except ValueError:
-            missing = [sid for sid in holdout_sample_ids if sid not in samples_list]
-            raise ValueError(f"Sample IDs not found in samples list: {missing}")
-        k = len(holdout_indices)
-
-    # Create IndexSet for holdout splitting
-    from locator.data.indexset import IndexSet
-
-    n_samples = len(samples)
-
-    if holdout_indices is not None:
-        holdout_idx = np.array(holdout_indices)
-        train_mask = np.ones(n_samples, dtype=bool)
-        train_mask[holdout_idx] = False
-        train_idx = np.where(train_mask)[0]
-
-        if na_mask is not None and (na_action == "exclude" or na_action == "separate"):
-            valid_mask = ~na_mask
-            holdout_idx = holdout_idx[valid_mask[holdout_idx]]
-            train_idx = train_idx[valid_mask[train_idx]]
-
-        index_set = IndexSet(
-            indices={"train": train_idx, "test": holdout_idx},
-            total_samples=n_samples,
-            na_mask=na_mask,
-        )
-    else:
-        index_set = IndexSet.random_split(
-            n=n_samples,
-            splits={
-                "train": 1.0 - k / n_samples,
-                "test": k / n_samples,
-            },
-            seed=locator.config.get("seed", 42),
-            na_mask=na_mask,
-            na_action=(na_action if na_action != "separate" else "exclude"),
-        )
+    index_set = _resolve_train_test_split(
+        locator,
+        samples,
+        locs,
+        na_mask,
+        na_action,
+        holdout_indices,
+        holdout_sample_ids,
+        k,
+    )
 
     if window_stop is None:
         window_stop = max(locator.positions)
 
-    # Generate windows
     from locator.data.windows import generate_genomic_windows
 
     chromosomes = getattr(locator, "chromosomes", None)
@@ -324,19 +207,16 @@ def parallel_windows_holdouts(  # noqa: C901
         verbose=verbose,
     )
 
-    # Pre-calculate KDE bandwidth if needed
     bw_train_mask = np.ones(len(samples), dtype=bool)
     bw_train_mask[index_set.test] = False
     bw_train_mask &= ~np.isnan(locs[:, 0])
-    bw_locs = locs[bw_train_mask]
     bw_calculated, bw_original = _precalculate_bandwidth(
         locator,
-        bw_locs,
-        f"windows_holdouts_n{len(bw_locs)}",
+        locs[bw_train_mask],
+        f"windows_holdouts_n{int(bw_train_mask.sum())}",
         verbose,
     )
 
-    # Normalize locations once
     from locator.data.filters import normalize_locs
 
     (
@@ -348,133 +228,143 @@ def parallel_windows_holdouts(  # noqa: C901
         normalized_locs,
     ) = normalize_locs(locs)
 
-    # Share data via Ray object store.
-    # NOTE: Windowed analysis requires the full genotype array because each
-    # window slices different SNP indices. Pre-filtering is not possible here
-    # unlike k-fold/holdout dispatchers.
-    data_ref = ray.put(
-        {
-            "genotypes_array": genotypes.values,
-            "samples": samples,
-            "sample_data": sample_data,
-            "config": locator.config,
-            "positions": locator.positions,
-            "windows": windows,
-            "index_set": index_set,
-            "meanlong": meanlong,
-            "sdlong": sdlong,
-            "meanlat": meanlat,
-            "sdlat": sdlat,
-            "unnormedlocs": unnormedlocs,
-            "normalized_locs": normalized_locs,
-        }
-    )
-
-    if verbose:
+    chunk_path = _windows_chunk_path(locator)
+    done_labels = _resume_completed_windows(chunk_path) if resume else set()
+    if done_labels and verbose:
         print(
-            f"Running windowed analysis for {len(windows)} "
-            f"windows across GPUs {gpu_ids} using Ray..."
+            f"Resume: {len(done_labels)} / {len(windows)} windows already "
+            f"present in {chunk_path}; skipping those."
         )
 
-    start_time = time.time()
-
-    _ray_windows_worker = _create_ray_windows_worker(gpu_fraction)
-
-    # Submit all windows to Ray
-    futures = []
-    for window_idx, window in enumerate(windows):
-        if len(gpu_ids) == 0:
-            gpu_id = -1
-        else:
-            gpu_id = gpu_ids[window_idx % len(gpu_ids)]
-
-        future = _ray_windows_worker.remote(
-            window_idx=window_idx,
-            window_start=window["start"],
-            window_stop=window["stop"],
-            gpu_id=gpu_id,
-            data=data_ref,
+    windows_to_run: List[Dict[str, Any]] = []
+    for wi, win in enumerate(windows):
+        label = win.get("label", f"pos{win['start']}")
+        if label in done_labels:
+            continue
+        snp_indices = (
+            np.where(win["indices"])[0].tolist()
+            if "indices" in win
+            else np.where(
+                (locator.positions >= win["start"]) & (locator.positions < win["stop"])
+            )[0].tolist()
         )
-        futures.append(future)
-        if verbose and window_idx < 10:
-            chrom_str = f" (chr{window['chromosome']})" if window["chromosome"] else ""
-            device_str = "CPU" if gpu_id == -1 else f"GPU {gpu_id}"
+        windows_to_run.append(
+            {
+                "window_idx": wi,
+                "window_label": label,
+                "window_chromosome": win.get("chromosome"),
+                "window_start": win["start"],
+                "window_stop": win["stop"],
+                "snp_indices": snp_indices,
+            }
+        )
+
+    if windows_to_run:
+        # Note: windowed analysis must materialize the full genotype array on
+        # the actor because every window slices a different SNP subset; we
+        # can't pre-filter to a small array as the other dispatchers do.
+        data_ref = ray.put(
+            {
+                "genotypes_array": genotypes.values,
+                "samples": samples,
+                "sample_data": sample_data,
+                "config": locator.config,
+                "index_set": index_set,
+                "meanlong": meanlong,
+                "sdlong": sdlong,
+                "meanlat": meanlat,
+                "sdlat": sdlat,
+                "unnormedlocs": unnormedlocs,
+                "normalized_locs": normalized_locs,
+            }
+        )
+
+        actors = make_window_actors(
+            gpu_ids=gpu_ids,
+            gpu_fraction=gpu_fraction,
+            data_ref=data_ref,
+            gpu_mem_mb=gpu_mem_mb,
+        )
+        if verbose:
             print(
-                f"Submitted window {window_idx}{chrom_str} "
-                f"({window['start']}-{window['stop']}) "
-                f"to {device_str}"
+                f"Spawned {len(actors)} WindowActor actors across GPUs {gpu_ids}; "
+                f"dispatching {len(windows_to_run)} windows "
+                f"(gpu_fraction={gpu_fraction})."
             )
 
-    if verbose and len(windows) > 10:
-        print(f"... and {len(windows) - 10} more windows")
+        pool = ActorPool(actors)
+        start_time = time.time()
 
-    # Wait for all windows to complete
-    results = _collect_ray_results(
-        futures,
-        desc="Windows completed",
-        postfix_fn=lambda r: (
-            f"Last: Window {r['window_idx']}"
-            + (f" (chr{r['window_chromosome']})" if r["window_chromosome"] else "")
-            + f", GPU {r['gpu_id']}"
-        ),
-        verbose=verbose,
-    )
+        pbar = None
+        if verbose:
+            try:
+                from tqdm import tqdm
 
-    total_time = time.time() - start_time
+                pbar = tqdm(total=len(windows_to_run), desc="Windows")
+            except ImportError:
+                pass
 
-    if verbose:
-        print(
-            f"\nCompleted {len(windows)} windows in "
-            f"{total_time:.1f}s "
-            f"({total_time / len(windows):.1f}s per window)"
-        )
+        completed = 0
+        for result in pool.map_unordered(
+            lambda actor, w: actor.run_window.remote(
+                w["window_idx"],
+                w["window_label"],
+                w["window_chromosome"],
+                w["window_start"],
+                w["window_stop"],
+                w["snp_indices"],
+            ),
+            windows_to_run,
+        ):
+            if result["rows"]:
+                _append_window_to_chunks(
+                    chunk_path, result["window_label"], result["rows"]
+                )
+            completed += 1
+            if pbar is not None:
+                pbar.update(1)
 
-        # Show GPU utilization summary
-        gpu_counts = {}
-        for result in results:
-            gid = result["gpu_id"]
-            gpu_counts[gid] = gpu_counts.get(gid, 0) + 1
+        if pbar is not None:
+            pbar.close()
 
-        print("\nGPU utilization:")
-        for gid in sorted(gpu_counts.keys()):
-            pct = gpu_counts[gid] / len(windows) * 100
-            print(f"  GPU {gid}: {gpu_counts[gid]} windows ({pct:.1f}%)")
+        total_time = time.time() - start_time
+        if verbose:
+            print(
+                f"\nCompleted {completed} windows in {total_time:.1f}s "
+                f"({total_time / max(completed, 1):.1f}s per window)."
+            )
+
+        for actor in actors:
+            ray.kill(actor)
+    elif verbose:
+        print("All windows already complete.")
 
     _restore_bandwidth(locator, bw_calculated, bw_original)
 
-    if return_df:
-        pred_dfs = []
+    if not return_df:
+        return None
 
-        for result in results:
-            if result["predictions"] is not None:
-                window_label = result.get(
-                    "window_label",
-                    f"pos{result['window_start']}",
-                )
-                predictions = pd.DataFrame(result["predictions"])
+    if not os.path.exists(chunk_path):
+        if verbose:
+            print("Warning: No windows produced predictions.")
+        return None
 
-                window_preds = predictions[["x_pred", "y_pred"]].copy()
-                window_preds.columns = [
-                    f"x_{window_label}",
-                    f"y_{window_label}",
-                ]
-                window_preds["sampleID"] = predictions["sampleID"]
-                pred_dfs.append(window_preds)
+    chunks = pd.read_csv(chunk_path)
+    if chunks.empty:
+        if verbose:
+            print("Warning: No windows produced predictions.")
+        return None
 
-        if not pred_dfs:
-            print("Warning: No windows contained SNPs. No predictions generated.")
-            return None
+    wide = chunks.pivot_table(
+        index="sampleID",
+        columns="window_label",
+        values=["x_pred", "y_pred"],
+        aggfunc="first",
+    )
+    wide.columns = [f"{val.replace('_pred', '')}_{label}" for val, label in wide.columns]
+    wide = wide.reset_index()
 
-        all_predictions = pred_dfs[0]
-        for df in pred_dfs[1:]:
-            all_predictions = pd.merge(all_predictions, df, on="sampleID")
+    if save_full_pred_matrix:
+        wide.to_csv(_windows_output_path(locator), index=False)
 
-        if save_full_pred_matrix:
-            all_predictions.to_csv(
-                f"{locator.config['out']}_windows_holdouts_predlocs.csv",
-                index=False,
-            )
-
-        return all_predictions
-
-    return None
+    return wide

--- a/locator/training.py
+++ b/locator/training.py
@@ -655,12 +655,12 @@ class TrainingMixin:
         # In window analysis, 'test' split contains the holdout samples
         self._store_holdout_state(index_set.get_split("test"), normalized_locs)
 
-        # For window analysis, we need to split the train indices into train/val
-        train_indices = index_set.get_split("train")
+        # For window analysis, we need to split the train indices into train/val.
+        # IndexSet arrays shipped via Ray are read-only; copy before shuffling.
+        train_indices = np.array(index_set.get_split("train"), copy=True)
         train_split = self.config.get("train_split", 0.9)
         n_train = int(len(train_indices) * train_split)
 
-        # Shuffle and split
         np.random.shuffle(train_indices)
         actual_train = train_indices[:n_train]
         actual_val = train_indices[n_train:]

--- a/tests/test_parallel_ensemble.py
+++ b/tests/test_parallel_ensemble.py
@@ -51,443 +51,77 @@ class TestParallelEnsemble:
 
         return genotypes, samples, coords_df
 
-    def test_parallel_train_ensemble_basic(self):
-        """Test basic parallel ensemble training functionality."""
+    def test_parallel_train_ensemble_cpu_smoke(self):
+        """End-to-end CPU smoke test for the actor-based ensemble path."""
         genotypes, samples, coords_df = self.create_test_data(n_samples=20, n_snps=50)
-
         with tempfile.TemporaryDirectory() as tmpdir:
             config = {
                 "sample_data": coords_df,
                 "max_epochs": 1,
+                "patience": 1,
+                "width": 8,
+                "nlayers": 2,
                 "keras_verbose": 0,
-                "out": os.path.join(tmpdir, "test"),
+                "out": os.path.join(tmpdir, "ens"),
             }
-
             locator = Locator(config)
+            from locator.parallel import parallel_train_ensemble
 
-            # Mock Ray to avoid actual parallel execution in tests
-            with (
-                patch("locator.parallel.ensemble.ray") as mock_ray,
-                patch("locator.parallel._helpers.ray", mock_ray),
-            ):
-                # Mock Ray initialization check
-                mock_ray.is_initialized.return_value = False
-                mock_ray.init.return_value = None
-
-                # Mock Ray worker submission and results
-                mock_future = MagicMock()
-                mock_ray.remote.return_value = mock_future
-
-                # Create mock results for each fold
-                mock_results = []
-                for fold_idx in range(3):
-                    mock_result = {
-                        "fold": fold_idx,
-                        "gpu_id": fold_idx % 2,
-                        "train_time": 10.0 + fold_idx,
-                        "model_info": {
-                            "fold": fold_idx,
-                            "weights_file": f"{config['out']}_fold{fold_idx}.weights.h5",
-                            "norm_params": {
-                                "meanlong": -90.0 + fold_idx,
-                                "sdlong": 10.0,
-                                "meanlat": 35.0 + fold_idx,
-                                "sdlat": 5.0,
-                            },
-                            "train_indices": list(range(10)),
-                            "val_indices": list(range(10, 15)),
-                        },
-                        "history": {
-                            "loss": [0.5, 0.4, 0.3],
-                            "val_loss": [0.6, 0.5, 0.4],
-                        },
-                        "final_loss": 0.3,
-                        "final_val_loss": 0.4,
-                    }
-                    mock_results.append(mock_result)
-
-                mock_ray.get.return_value = mock_results
-                mock_ray.wait.return_value = ([MagicMock()], [])
-
-                # Mock the worker creation
-                with patch(
-                    "locator.parallel.ensemble._create_ray_ensemble_worker"
-                ) as mock_worker:
-                    mock_worker.return_value.remote.return_value = mock_future
-
-                    # Import and call parallel_train_ensemble
-                    from locator.parallel import parallel_train_ensemble
-
-                    # Mock time to make the test faster
-                    with patch("time.time", side_effect=[0, 10]):
-                        result = parallel_train_ensemble(
-                            locator=locator,
-                            genotypes=genotypes,
-                            samples=samples,
-                            k=3,
-                            gpu_ids=[0, 1],
-                            save_fold_models=False,
-                            use_model_manager=False,
-                            verbose=False,
-                        )
-
-                    # Check results
-                    assert result is not None
-                    assert "histories" in result
-                    assert "models" in result
-                    assert "normalization_params" in result
-                    assert len(result["models"]) == 3
-
-                    # Check that averaged normalization parameters are calculated
-                    avg_params = result["normalization_params"]
-                    assert "meanlong" in avg_params
-                    assert "meanlat" in avg_params
-
-    def test_parallel_vs_sequential_consistency(self):
-        """Test that parallel ensemble gives similar results to sequential."""
-        genotypes, samples, coords_df = self.create_test_data(n_samples=20, n_snps=50)
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            config = {
-                "sample_data": coords_df,
-                "max_epochs": 1,
-                "keras_verbose": 0,
-                "out": os.path.join(tmpdir, "test"),
-                "seed": 42,
-            }
-
-            # Train sequential ensemble
-            locator_seq = Locator(config.copy())
-            seq_result = locator_seq.train_ensemble(
+            result = parallel_train_ensemble(
+                locator=locator,
                 genotypes=genotypes,
                 samples=samples,
                 k=2,
+                gpu_ids=[],
+                gpu_fraction=0.0,
                 save_fold_models=False,
+                use_model_manager=False,
                 verbose=False,
             )
-
-            # For parallel, we'll mock to return similar structure
-            locator_par = Locator(config.copy())
-
-            with (
-                patch("locator.parallel.ensemble.ray") as mock_ray,
-                patch("locator.parallel._helpers.ray", mock_ray),
-            ):
-                mock_ray.is_initialized.return_value = False
-
-                # Use sequential results to create parallel mock results
-                mock_results = []
-                for i in range(2):
-                    mock_result = {
-                        "fold": i,
-                        "gpu_id": i,
-                        "train_time": 5.0,
-                        "model_info": {
-                            "fold": i,
-                            "weights_file": None,
-                            "norm_params": seq_result["models"][i]["norm_params"],
-                            "train_indices": seq_result["models"][i][
-                                "train_indices"
-                            ].tolist(),
-                            "val_indices": seq_result["models"][i][
-                                "val_indices"
-                            ].tolist(),
-                        },
-                        "history": {
-                            "loss": seq_result["histories"][i].history.get("loss", []),
-                            "val_loss": seq_result["histories"][i].history.get(
-                                "val_loss", []
-                            ),
-                        },
-                        "final_loss": 0.3,
-                        "final_val_loss": 0.4,
-                    }
-                    mock_results.append(mock_result)
-
-                mock_ray.get.return_value = mock_results
-
-                from locator.parallel import parallel_train_ensemble
-
-                with patch(
-                    "locator.parallel.ensemble._create_ray_ensemble_worker"
-                ) as mock_worker:
-                    mock_future = MagicMock()
-                    mock_worker.return_value.remote.return_value = mock_future
-
-                    par_result = parallel_train_ensemble(
-                        locator=locator_par,
-                        genotypes=genotypes,
-                        samples=samples,
-                        k=2,
-                        gpu_ids=[0, 1],
-                        save_fold_models=False,
-                        use_model_manager=False,
-                        verbose=False,
-                    )
-
-                # Compare normalization parameters
-                seq_norm = seq_result["normalization_params"]
-                par_norm = par_result["normalization_params"]
-
-                assert abs(seq_norm["meanlong"] - par_norm["meanlong"]) < 1e-6
-                assert abs(seq_norm["meanlat"] - par_norm["meanlat"]) < 1e-6
-
-    def test_parallel_ensemble_with_na_samples(self):
-        """Test parallel ensemble with NA samples."""
-        genotypes, samples, coords_df = self.create_test_data(n_samples=20, n_snps=50)
-
-        # Add some NA samples
-        coords_df.loc[15:19, ["x", "y"]] = np.nan
-
-        config = {
-            "sample_data": coords_df,
-            "max_epochs": 1,
-            "keras_verbose": 0,
+        assert set(result.keys()) >= {
+            "histories",
+            "models",
+            "normalization_params",
+            "fold_info",
+            "training_time",
+            "parallel",
         }
+        assert len(result["models"]) == 2
+        assert {"meanlong", "meanlat", "sdlong", "sdlat"} <= set(
+            result["normalization_params"].keys()
+        )
 
-        locator = Locator(config)
-        locator.na_action = "separate"
-
-        # Mock Ray
-        with (
-            patch("locator.parallel.ensemble.ray") as mock_ray,
-            patch("locator.parallel._helpers.ray", mock_ray),
-        ):
-            mock_ray.is_initialized.return_value = False
-
-            # Create minimal mock results
-            mock_results = []
-            for fold_idx in range(3):
-                mock_result = {
-                    "fold": fold_idx,
-                    "gpu_id": fold_idx % 2,
-                    "train_time": 5.0,
-                    "model_info": {
-                        "fold": fold_idx,
-                        "weights_file": None,
-                        "norm_params": {
-                            "meanlong": -90.0,
-                            "sdlong": 10.0,
-                            "meanlat": 35.0,
-                            "sdlat": 5.0,
-                        },
-                        "train_indices": list(range(10)),
-                        "val_indices": list(range(10, 15)),
-                    },
-                    "history": {"loss": [0.5], "val_loss": [0.6]},
-                    "final_loss": 0.5,
-                    "final_val_loss": 0.6,
-                }
-                mock_results.append(mock_result)
-
-            mock_ray.get.return_value = mock_results
-
-            from locator.parallel import parallel_train_ensemble
-
-            with patch(
-                "locator.parallel.ensemble._create_ray_ensemble_worker"
-            ) as mock_worker:
-                mock_future = MagicMock()
-                mock_worker.return_value.remote.return_value = mock_future
-
-                result = parallel_train_ensemble(
-                    locator=locator,
-                    genotypes=genotypes,
-                    samples=samples,
-                    k=3,
-                    gpu_ids=[0, 1],
-                    na_action="separate",
-                    save_fold_models=False,
-                    use_model_manager=False,
-                    verbose=False,
-                )
-
-                assert result is not None
-                assert "fold_info" in result
-                # Should have identified NA samples
-                assert result["fold_info"]["sample_status"]["n_na"] == 5
-
-    def test_parallel_ensemble_gpu_assignment(self):
-        """Test that GPU assignment works correctly in parallel ensemble."""
+    def test_parallel_train_ensemble_cpu_with_na_samples(self):
+        """Ensemble with NA-coord samples runs (excluded from training)."""
         genotypes, samples, coords_df = self.create_test_data(n_samples=20, n_snps=50)
-
-        config = {
-            "sample_data": coords_df,
-            "max_epochs": 1,
-            "keras_verbose": 0,
-        }
-
-        locator = Locator(config)
-
-        # Track GPU assignments
-        gpu_assignments = []
-
-        def track_gpu_assignment(fold_idx, gpu_id, data):
-            gpu_assignments.append((fold_idx, gpu_id))
-            # data parameter is required by interface but not used here
-            _ = data
-            mock_future = MagicMock()
-            return mock_future
-
-        with (
-            patch("locator.parallel.ensemble.ray") as mock_ray,
-            patch("locator.parallel._helpers.ray", mock_ray),
-        ):
-            mock_ray.is_initialized.return_value = False
-
-            # Create mock results
-            mock_results = []
-            for fold_idx in range(5):
-                mock_result = {
-                    "fold": fold_idx,
-                    "gpu_id": fold_idx % 3,  # Should match our GPU assignment
-                    "train_time": 5.0,
-                    "model_info": {
-                        "fold": fold_idx,
-                        "weights_file": None,
-                        "norm_params": {
-                            "meanlong": -90.0,
-                            "sdlong": 10.0,
-                            "meanlat": 35.0,
-                            "sdlat": 5.0,
-                        },
-                        "train_indices": list(range(10)),
-                        "val_indices": list(range(10, 15)),
-                    },
-                    "history": {"loss": [0.5], "val_loss": [0.6]},
-                    "final_loss": 0.5,
-                    "final_val_loss": 0.6,
-                }
-                mock_results.append(mock_result)
-
-            mock_ray.get.return_value = mock_results
-
-            from locator.parallel import parallel_train_ensemble
-
-            with patch(
-                "locator.parallel.ensemble._create_ray_ensemble_worker"
-            ) as mock_worker:
-                mock_worker.return_value.remote.side_effect = track_gpu_assignment
-
-                _ = parallel_train_ensemble(
-                    locator=locator,
-                    genotypes=genotypes,
-                    samples=samples,
-                    k=5,
-                    gpu_ids=[0, 1, 2],  # 3 GPUs
-                    save_fold_models=False,
-                    use_model_manager=False,
-                    verbose=False,
-                )
-
-                # Check GPU assignments
-                expected_assignments = [
-                    (0, 0),  # Fold 0 -> GPU 0
-                    (1, 1),  # Fold 1 -> GPU 1
-                    (2, 2),  # Fold 2 -> GPU 2
-                    (3, 0),  # Fold 3 -> GPU 0 (round-robin)
-                    (4, 1),  # Fold 4 -> GPU 1
-                ]
-
-                assert gpu_assignments == expected_assignments
-
-    @pytest.mark.skipif(
-        "CI" in os.environ,
-        reason="Skip model manager test in CI to avoid file I/O issues",
-    )
-    def test_parallel_ensemble_with_model_manager(self):
-        """Test parallel ensemble with model manager saving."""
-        genotypes, samples, coords_df = self.create_test_data(n_samples=20, n_snps=50)
-
+        coords_df = coords_df.copy()
+        coords_df.loc[16:, ["x", "y"]] = np.nan
         with tempfile.TemporaryDirectory() as tmpdir:
             config = {
                 "sample_data": coords_df,
                 "max_epochs": 1,
+                "patience": 1,
+                "width": 8,
+                "nlayers": 2,
                 "keras_verbose": 0,
-                "out": os.path.join(tmpdir, "test"),
+                "out": os.path.join(tmpdir, "ens_na"),
+                "na_action": "exclude",
             }
-
             locator = Locator(config)
+            from locator.parallel import parallel_train_ensemble
 
-            # Mock Ray and model creation
-            with (
-                patch("locator.parallel.ensemble.ray") as mock_ray,
-                patch("locator.parallel._helpers.ray", mock_ray),
-            ):
-                mock_ray.is_initialized.return_value = False
-
-                # Create mock results
-                mock_results = []
-                for fold_idx in range(2):
-                    mock_result = {
-                        "fold": fold_idx,
-                        "gpu_id": fold_idx,
-                        "train_time": 5.0,
-                        "model_info": {
-                            "fold": fold_idx,
-                            "weights_file": f"{config['out']}_fold{fold_idx}.weights.h5",
-                            "norm_params": {
-                                "meanlong": -90.0,
-                                "sdlong": 10.0,
-                                "meanlat": 35.0,
-                                "sdlat": 5.0,
-                            },
-                            "train_indices": list(range(10)),
-                            "val_indices": list(range(10, 15)),
-                        },
-                        "history": {"loss": [0.5], "val_loss": [0.6]},
-                        "final_loss": 0.5,
-                        "final_val_loss": 0.6,
-                    }
-                    mock_results.append(mock_result)
-
-                mock_ray.get.return_value = mock_results
-
-                from locator.parallel import parallel_train_ensemble
-
-                with patch(
-                    "locator.parallel.ensemble._create_ray_ensemble_worker"
-                ) as mock_worker:
-                    mock_future = MagicMock()
-                    mock_worker.return_value.remote.return_value = mock_future
-
-                    # Mock model creation and loading
-                    with patch.object(locator, "_create_model") as mock_create_model:
-                        mock_model = MagicMock()
-                        mock_create_model.return_value = mock_model
-
-                        # Mock os.path.exists so fake weight files pass the check
-                        with patch(
-                            "locator.parallel.ensemble.os.path.exists",
-                            return_value=True,
-                        ):
-                            # Mock EnsembleModelManager
-                            with patch(
-                                "locator.ensemble_model_manager.EnsembleModelManager"
-                            ) as mock_manager_class:
-                                mock_manager = MagicMock()
-                                mock_manager_class.return_value = mock_manager
-
-                                _ = parallel_train_ensemble(
-                                    locator=locator,
-                                    genotypes=genotypes,
-                                    samples=samples,
-                                    k=2,
-                                    gpu_ids=[0, 1],
-                                    save_fold_models=True,
-                                    use_model_manager=True,
-                                    verbose=False,
-                                )
-
-                                # Verify model manager was used
-                                mock_manager_class.assert_called_once()
-                                mock_manager.save_ensemble.assert_called_once()
-
-                                # Check metadata includes parallel training info
-                                call_args = mock_manager.save_ensemble.call_args
-                                metadata = call_args[0][1]
-                                assert metadata["parallel_training"] is True
-                                assert metadata["gpu_ids"] == [0, 1]
+            result = parallel_train_ensemble(
+                locator=locator,
+                genotypes=genotypes,
+                samples=samples,
+                k=2,
+                gpu_ids=[],
+                gpu_fraction=0.0,
+                save_fold_models=False,
+                use_model_manager=False,
+                verbose=False,
+            )
+        assert len(result["models"]) == 2
 
     # Integration tests (from test_parallel_ensemble_integration.py)
 

--- a/tests/test_parallel_holdout.py
+++ b/tests/test_parallel_holdout.py
@@ -14,7 +14,17 @@ import pytest
 from conftest import make_test_genotypes
 
 from locator import Locator
-from locator.parallel import parallel_holdouts
+
+try:
+    import ray  # noqa: F401
+
+    RAY_AVAILABLE = True
+except ImportError:
+    RAY_AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not RAY_AVAILABLE, reason="Ray not installed")
+
+from locator.parallel import parallel_holdouts  # noqa: E402
 
 
 @pytest.fixture

--- a/tests/test_parallel_holdout.py
+++ b/tests/test_parallel_holdout.py
@@ -1,0 +1,113 @@
+"""Tests for the actor-based parallel_holdouts dispatcher.
+
+Same setup as test_parallel_kfold but exercising the holdout path: wide-format
+output (x_rep0/y_rep0/x_rep1/...), long-format per-replicate checkpointing,
+and resume semantics.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pandas as pd
+import pytest
+from conftest import make_test_genotypes
+
+from locator import Locator
+from locator.parallel import parallel_holdouts
+
+
+@pytest.fixture
+def small_data(tmp_path):
+    genotypes, samples, sample_df = make_test_genotypes(
+        n_snps=200, n_samples=20, n_known=20
+    )
+    sample_file = tmp_path / "samples.txt"
+    content = "sampleID\tx\ty\n"
+    for sid, (x, y) in zip(samples, sample_df[["x", "y"]].values, strict=True):
+        content += f"{sid}\t{x}\t{y}\n"
+    sample_file.write_text(content)
+
+    config = {
+        "out": str(tmp_path / "holdout_test"),
+        "sample_data": str(sample_file),
+        "max_epochs": 2,
+        "patience": 1,
+        "batch_size": 4,
+        "width": 16,
+        "nlayers": 2,
+        "keras_verbose": 0,
+        "verbose_splits": False,
+        "holdout_no_intermediate_saves": True,
+        "save_fold_models": False,
+    }
+    return Locator(config), genotypes, samples, tmp_path
+
+
+@pytest.mark.slow
+def test_parallel_holdouts_cpu_smoke(small_data):
+    """Three replicates on CPU; verify wide-format output + chunk file."""
+    loc, genotypes, samples, tmp_path = small_data
+    df = parallel_holdouts(
+        locator=loc,
+        genotypes=genotypes,
+        samples=samples,
+        k=3,
+        n_reps=3,
+        gpu_ids=[],
+        gpu_fraction=0.0,
+        return_df=True,
+        save_full_pred_matrix=True,
+        verbose=False,
+    )
+    assert "sampleID" in df.columns
+    for rep in range(3):
+        assert f"x_rep{rep}" in df.columns
+        assert f"y_rep{rep}" in df.columns
+
+    chunk_path = str(tmp_path / "holdout_test_holdouts_chunks.csv")
+    assert os.path.exists(chunk_path)
+    chunks = pd.read_csv(chunk_path)
+    assert set(chunks["rep"].unique()) == {0, 1, 2}
+
+
+@pytest.mark.slow
+def test_parallel_holdouts_resume(small_data):
+    """Pre-seeded chunk file → dispatcher skips done replicates and tops up the rest."""
+    loc, genotypes, samples, tmp_path = small_data
+    chunk_path = str(tmp_path / "holdout_test_holdouts_chunks.csv")
+
+    rows = []
+    for rep in (0, 1):
+        for sid in samples:
+            rows.append(
+                {
+                    "sampleID": str(sid),
+                    "x_pred": -110.0,
+                    "y_pred": 35.0,
+                    "rep": rep,
+                }
+            )
+    pd.DataFrame(rows).to_csv(chunk_path, index=False)
+
+    df = parallel_holdouts(
+        locator=loc,
+        genotypes=genotypes,
+        samples=samples,
+        k=3,
+        n_reps=4,
+        gpu_ids=[],
+        gpu_fraction=0.0,
+        return_df=True,
+        save_full_pred_matrix=False,
+        verbose=False,
+        resume=True,
+    )
+    chunks = pd.read_csv(chunk_path)
+    assert sorted(chunks["rep"].unique()) == [0, 1, 2, 3]
+    # Reps 0 and 1 should still be the seeded values
+    seeded = chunks[chunks["rep"] == 0]
+    assert (seeded["x_pred"] == -110.0).all()
+    # Wide output covers all four reps
+    for rep in range(4):
+        assert f"x_rep{rep}" in df.columns

--- a/tests/test_parallel_kfold.py
+++ b/tests/test_parallel_kfold.py
@@ -1,0 +1,132 @@
+"""Tests for the actor-based k-fold / LOO parallel dispatcher.
+
+These hit the new ``locator.parallel.kfold`` path: per-fold checkpointing,
+resume behavior, and the basic Ray ActorPool round-trip. They run on CPU
+(``gpu_ids=[]``) to keep the test suite portable.
+"""
+
+from __future__ import annotations
+
+import os
+
+import numpy as np
+import pandas as pd
+import pytest
+from conftest import make_test_genotypes
+
+from locator import Locator
+from locator.parallel import parallel_k_fold_holdouts, parallel_leave_one_out
+
+
+@pytest.fixture
+def small_data(tmp_path):
+    """Tiny synthetic dataset + persisted sample TSV; CPU-runnable."""
+    genotypes, samples, sample_df = make_test_genotypes(
+        n_snps=200, n_samples=20, n_known=20
+    )
+    sample_file = tmp_path / "samples.txt"
+    content = "sampleID\tx\ty\n"
+    for sid, (x, y) in zip(samples, sample_df[["x", "y"]].values, strict=True):
+        content += f"{sid}\t{x}\t{y}\n"
+    sample_file.write_text(content)
+
+    config = {
+        "out": str(tmp_path / "kfold_test"),
+        "sample_data": str(sample_file),
+        "max_epochs": 2,
+        "patience": 1,
+        "batch_size": 4,
+        "width": 16,
+        "nlayers": 2,
+        "keras_verbose": 0,
+        "verbose_splits": False,
+        "holdout_no_intermediate_saves": True,
+        "save_fold_models": False,
+    }
+    return Locator(config), genotypes, samples, tmp_path
+
+
+def _assert_predictions_shape(df, expected_samples, expected_folds):
+    assert set(df.columns) == {"sampleID", "x_pred", "y_pred", "fold"}
+    assert df["fold"].nunique() == expected_folds
+    assert set(df["sampleID"].astype(str).unique()) == set(map(str, expected_samples))
+
+
+@pytest.mark.slow
+def test_parallel_k_fold_cpu_smoke(small_data):
+    """Three folds on CPU; verify output structure + checkpoint file."""
+    loc, genotypes, samples, tmp_path = small_data
+    df = parallel_k_fold_holdouts(
+        locator=loc,
+        genotypes=genotypes,
+        samples=samples,
+        k=3,
+        gpu_ids=[],
+        gpu_fraction=0.0,
+        return_df=True,
+        verbose=False,
+    )
+    _assert_predictions_shape(df, samples, expected_folds=3)
+    csv_path = str(tmp_path / "kfold_test_kfold_holdouts_predlocs.csv")
+    assert os.path.exists(csv_path)
+    on_disk = pd.read_csv(csv_path)
+    assert len(on_disk) == len(df)
+
+
+@pytest.mark.slow
+def test_parallel_k_fold_resume(small_data):
+    """First run writes 2 folds; second run with k=4 completes remaining 2."""
+    loc, genotypes, samples, tmp_path = small_data
+    csv_path = str(tmp_path / "kfold_test_kfold_holdouts_predlocs.csv")
+
+    # Seed the checkpoint file with two folds' worth of fake rows so the
+    # dispatcher should skip them and only run folds 2 and 3.
+    rng = np.random.default_rng(0)
+    rows = []
+    for fold in (0, 1):
+        for sid in samples:
+            rows.append(
+                {
+                    "sampleID": str(sid),
+                    "x_pred": float(rng.uniform(-120, -100)),
+                    "y_pred": float(rng.uniform(30, 50)),
+                    "fold": fold,
+                }
+            )
+    pd.DataFrame(rows).to_csv(csv_path, index=False)
+
+    df = parallel_k_fold_holdouts(
+        locator=loc,
+        genotypes=genotypes,
+        samples=samples,
+        k=4,
+        gpu_ids=[],
+        gpu_fraction=0.0,
+        return_df=True,
+        verbose=False,
+        resume=True,
+    )
+    # All four folds should be present after resume
+    assert sorted(df["fold"].unique()) == [0, 1, 2, 3]
+    # Folds 0/1 should still be the seeded rows (untouched)
+    seeded_fold_0 = pd.read_csv(csv_path)[lambda d: d["fold"] == 0]
+    assert len(seeded_fold_0) == len(samples)
+
+
+@pytest.mark.slow
+def test_parallel_leave_one_out_cpu(small_data):
+    """LOO on CPU with a tiny dataset — checks the LOO wrapper path."""
+    loc, genotypes, samples, tmp_path = small_data
+    df = parallel_leave_one_out(
+        locator=loc,
+        genotypes=genotypes,
+        samples=samples,
+        gpu_ids=[],
+        gpu_fraction=0.0,
+        return_df=True,
+        save_full_pred_matrix=True,
+    )
+    _assert_predictions_shape(df, samples, expected_folds=len(samples))
+    # LOO writes its own aggregated CSV under a distinct suffix
+    loo_csv = str(tmp_path / "kfold_test_leave_one_out_predlocs.csv")
+    assert os.path.exists(loo_csv)

--- a/tests/test_parallel_kfold.py
+++ b/tests/test_parallel_kfold.py
@@ -15,7 +15,20 @@ import pytest
 from conftest import make_test_genotypes
 
 from locator import Locator
-from locator.parallel import parallel_k_fold_holdouts, parallel_leave_one_out
+
+try:
+    import ray  # noqa: F401
+
+    RAY_AVAILABLE = True
+except ImportError:
+    RAY_AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not RAY_AVAILABLE, reason="Ray not installed")
+
+from locator.parallel import (  # noqa: E402
+    parallel_k_fold_holdouts,
+    parallel_leave_one_out,
+)
 
 
 @pytest.fixture

--- a/tests/test_parallel_windowed.py
+++ b/tests/test_parallel_windowed.py
@@ -1,0 +1,77 @@
+"""Smoke test for the actor-based parallel_windows_holdouts dispatcher."""
+
+from __future__ import annotations
+
+import os
+
+import numpy as np
+import pandas as pd
+import pytest
+from conftest import make_test_genotypes
+
+from locator import Locator
+from locator.parallel import parallel_windows_holdouts
+
+
+@pytest.fixture
+def small_data_with_positions(tmp_path):
+    genotypes, samples, sample_df = make_test_genotypes(
+        n_snps=100, n_samples=20, n_known=20
+    )
+    sample_file = tmp_path / "samples.txt"
+    content = "sampleID\tx\ty\n"
+    for sid, (x, y) in zip(samples, sample_df[["x", "y"]].values, strict=True):
+        content += f"{sid}\t{x}\t{y}\n"
+    sample_file.write_text(content)
+
+    config = {
+        "out": str(tmp_path / "win_test"),
+        "sample_data": str(sample_file),
+        "max_epochs": 2,
+        "patience": 1,
+        "batch_size": 4,
+        "width": 16,
+        "nlayers": 2,
+        "keras_verbose": 0,
+        "verbose_splits": False,
+        "holdout_no_intermediate_saves": True,
+        "save_fold_models": False,
+        "min_snps_per_window": 5,
+    }
+    loc = Locator(config)
+    # Inject synthetic positions on a single chromosome so the dispatcher
+    # doesn't need to load from VCF/zarr.
+    loc.positions = np.arange(1, len(genotypes) + 1) * 1000
+    return loc, genotypes, samples, tmp_path
+
+
+@pytest.mark.slow
+def test_parallel_windows_holdouts_cpu_smoke(small_data_with_positions):
+    """Two windows on CPU; verify wide-format output + chunk file."""
+    loc, genotypes, samples, tmp_path = small_data_with_positions
+    holdout_indices = list(range(0, 4))  # hold out first 4 samples
+    df = parallel_windows_holdouts(
+        locator=loc,
+        genotypes=genotypes,
+        samples=samples,
+        window_start=0,
+        window_size=50_000,
+        respect_chromosomes=False,
+        holdout_indices=holdout_indices,
+        gpu_ids=[],
+        gpu_fraction=0.0,
+        return_df=True,
+        save_full_pred_matrix=True,
+        verbose=False,
+    )
+    assert df is not None
+    assert "sampleID" in df.columns
+    # At least one x_<label> / y_<label> pair per window present
+    x_cols = [c for c in df.columns if c.startswith("x_")]
+    y_cols = [c for c in df.columns if c.startswith("y_")]
+    assert len(x_cols) >= 1 and len(y_cols) == len(x_cols)
+
+    chunk_path = str(tmp_path / "win_test_windows_chunks.csv")
+    assert os.path.exists(chunk_path)
+    chunks = pd.read_csv(chunk_path)
+    assert chunks["window_label"].nunique() >= 1

--- a/tests/test_parallel_windowed.py
+++ b/tests/test_parallel_windowed.py
@@ -10,7 +10,17 @@ import pytest
 from conftest import make_test_genotypes
 
 from locator import Locator
-from locator.parallel import parallel_windows_holdouts
+
+try:
+    import ray  # noqa: F401
+
+    RAY_AVAILABLE = True
+except ImportError:
+    RAY_AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not RAY_AVAILABLE, reason="Ray not installed")
+
+from locator.parallel import parallel_windows_holdouts  # noqa: E402
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Converts all four parallel dispatchers (`parallel_k_fold_holdouts`, `parallel_leave_one_out`, `parallel_holdouts`, `parallel_train_ensemble`, `parallel_windows_holdouts`) from per-unit Ray tasks to long-lived Ray actors. Each actor is created once per GPU scheduling slot, holds a hot TF runtime + reusable Locator, and serves many units of work via a single method — the TF graph + autograph + XLA caches survive across calls. For LOO with hundreds of folds (or windowed analysis with thousands of windows), this eliminates the multi-second per-unit cold-start tax that previously dominated wall time.

## What's in scope

- `locator/parallel/_actor.py` (new) — three actor classes (`FoldWorker`, `EnsembleActor`, `WindowActor`) sharing an `_init_actor_runtime` helper. The helper installs a per-process TF memory cap matching `gpu_fraction` via `tf.config.set_logical_device_configuration`, so co-tenant actors on the same GPU can't OOM each other when XLA workspaces peak. Falls back to memory_growth if TF was already touched.
- `locator/parallel/kfold.py`, `holdout.py`, `ensemble.py`, `windowed.py` — rewritten to dispatch via `ray.util.ActorPool.map_unordered`. Public API signatures unchanged.
- **Per-unit checkpointing**: k-fold/LOO/holdout/windowed now append each fold/replicate/window's predictions to disk as they complete; `resume=True` (default) skips units already present. Big win for crash-safety on multi-hour runs — previously, a mid-sweep failure discarded all completed-but-not-yet-aggregated work.
- **Bug fix in `train_window`** — was mutating `IndexSet` train indices in place via `np.random.shuffle`. Arrays shipped via Ray's object store are read-only, so this would crash on any windowed run on a current Ray. Copy before shuffling.
- **Tests** — added `test_parallel_kfold.py`, `test_parallel_holdout.py`, `test_parallel_windowed.py` with CPU end-to-end smoke + resume tests. Replaced 5 deeply Ray-mocked tests in `test_parallel_ensemble.py` with 2 CPU smoke tests against the actor path; kept the 6 unchanged structural tests. 24 tests pass.

## Why

Existing audit identified two structural drains on LOO throughput:
1. **Per-fold cold start**: each Ray task spun up a fresh Python process, re-imported TF, re-built the model, and re-compiled XLA. The explicit `tf.keras.backend.clear_session()` after every fold also nuked the JIT cache that would otherwise survive. For 236 LOO folds at 2M SNPs, that overhead was substantial (8-30s/fold × hundreds of folds, partially amortized but never eliminated). Actors with hot runtimes solve this directly.
2. **`gpu_fraction` was a scheduling hint, not a memory cap.** Three workers packed on one A100 could collectively try to allocate >80 GB during XLA peak; OOMs were random and hard to debug. `set_logical_device_configuration` now enforces a hard cap matching the fraction.

## Test plan

- [x] `pixi run pytest tests/test_parallel_{kfold,holdout,windowed,ensemble}.py tests/test_filters.py tests/test_doc_examples.py::TestParallelExamples` — all pass (24 tests).
- [ ] Real-GPU benchmark vs main: same LOO/k-fold workload, measure end-to-end wall time (planned before merge).

## Out of scope

- Holding off on architectural LOO efficiency improvements (one base model + fine-tune per fold) flagged in the audit. Those are research-grade changes; this PR is purely the orchestration refactor.

Branch contains two commits: the initial k-fold/LOO refactor (`e490250`) and the rollout to the other three dispatchers (`6bdb604`).