### PR TITLE
Add PCA-initialized projection training mode

### DIFF
--- a/locator/cli.py
+++ b/locator/cli.py
@@ -136,6 +136,29 @@ def parse_args():
                           default: 256",
     )
     parser.add_argument(
+        "--pca_components",
+        default=None,
+        type=int,
+        help="If set, prepend a PCA-initialized linear projection of this "
+        "width as the first layer and fine-tune it. Recommended when the "
+        "number of SNPs greatly exceeds the number of samples. "
+        "default: None (disabled)",
+    )
+    parser.add_argument(
+        "--no_pca_finetune",
+        dest="pca_finetune",
+        default=True,
+        action="store_false",
+        help="Keep the PCA projection frozen at its PCA initialization "
+        "instead of running the low-learning-rate fine-tuning phase.",
+    )
+    parser.add_argument(
+        "--pca_finetune_lr",
+        default=1e-4,
+        type=float,
+        help="Learning rate for the PCA fine-tuning phase. default: 1e-4",
+    )
+    parser.add_argument(
         "--out",
         help="file name stem for output",
     )

--- a/locator/core.py
+++ b/locator/core.py
@@ -165,6 +165,9 @@ class Locator(
         - **width** (*int*): Width of neural network layers.
         - **nlayers** (*int*): Number of neural network layers.
         - **dropout_prop** (*float*): Dropout proportion.
+        - **pca_components** (*int*): If set, prepend a PCA-initialized linear projection of this width as the first layer and fine-tune it. Recommended when n_SNPs >> n_samples. Default None (disabled).
+        - **pca_finetune** (*bool*): Whether to unfreeze the PCA projection for a low-learning-rate fine-tuning phase. Default True. False keeps the projection frozen at its PCA initialization.
+        - **pca_finetune_lr** (*float*): Learning rate for the PCA fine-tuning phase. Default 1e-4.
         - **keras_verbose** (*int*): Verbosity level for Keras training.
         - **impute_missing** (*bool*): Whether to impute missing genotypes.
         - **validation_split** (*float*): Proportion of data to use for validation.
@@ -207,6 +210,10 @@ class Locator(
             "width": 256,
             "nlayers": 8,
             "dropout_prop": 0.25,
+            # PCA-initialized projection (for n_SNPs >> n_samples)
+            "pca_components": None,
+            "pca_finetune": True,
+            "pca_finetune_lr": 1e-4,
             # Training parameters
             "max_epochs": 5000,
             "patience": 100,

--- a/locator/ensemble_mixin.py
+++ b/locator/ensemble_mixin.py
@@ -294,6 +294,10 @@ class EnsembleMixin:
             "sdlat": sdlat,
         }
 
+        # Expose the fold's split so _create_model can fit per-fold PCA on the
+        # training samples when pca_components is enabled.
+        self.index_set = index_set
+
         # Create model
         model = self._create_model(input_shape=filtered_genotypes.shape[0])
 
@@ -336,13 +340,13 @@ class EnsembleMixin:
             fold_idx, save_fold_models, patience_multiplier
         )
 
-        # Train model
-        history = model.fit(
+        # Train model (runs the two-phase PCA fine-tune when enabled)
+        history = self._fit_model(
+            model,
             train_dataset,
-            epochs=self.config.get("max_epochs", 5000),
-            verbose=self.config.get("keras_verbose", 1) if verbose else 0,
-            validation_data=val_dataset,
-            callbacks=callbacks,
+            val_dataset,
+            callbacks,
+            keras_verbose=self.config.get("keras_verbose", 1) if verbose else 0,
         )
 
         # Return model info

--- a/locator/models.py
+++ b/locator/models.py
@@ -165,10 +165,15 @@ def create_network(
     # Optional PCA-initialized linear projection as the first layer. Placed
     # before BatchNormalization so it sees raw genotype counts, which lets a
     # caller set its weights to PCA loadings and reproduce PCA scores exactly.
+    # Pinned to float32: it computes raw_counts @ loadings + bias, where the
+    # two terms are large and nearly cancel, so float16 loses the result.
     if pca_components is not None:
-        x = layers.Dense(pca_components, activation="linear", name=PCA_LAYER_NAME)(
-            inputs
-        )
+        x = layers.Dense(
+            pca_components,
+            activation="linear",
+            name=PCA_LAYER_NAME,
+            dtype="float32",
+        )(inputs)
         x = layers.BatchNormalization()(x)
     else:
         x = layers.BatchNormalization()(inputs)

--- a/locator/models.py
+++ b/locator/models.py
@@ -11,6 +11,30 @@ from tensorflow import keras
 from tensorflow.keras import backend as K
 from tensorflow.keras import layers
 
+PCA_LAYER_NAME = "pca_projection"
+
+
+def build_optimizer(algo, learning_rate, weight_decay=0.004):
+    """Build a Keras optimizer from an algorithm name.
+
+    Args:
+        algo: "adam" or "adamw" (case-insensitive).
+        learning_rate: Learning rate.
+        weight_decay: Weight decay, used only for AdamW.
+
+    Returns
+    -------
+        A configured keras optimizer.
+    """
+    algo = algo.lower()
+    if algo == "adam":
+        return keras.optimizers.Adam(learning_rate=learning_rate)
+    if algo == "adamw":
+        return keras.optimizers.AdamW(
+            learning_rate=learning_rate, weight_decay=weight_decay
+        )
+    raise ValueError(f"Unsupported optimizer: {algo}")
+
 
 def rasterize_species_range(shapefile_path, resolution=0.1):
     gdf = gpd.read_file(shapefile_path)
@@ -97,6 +121,7 @@ def create_network(
     width: int = 256,
     n_layers: int = 8,
     dropout_prop: float = 0.25,
+    pca_components: Optional[int] = None,
     optimizer_config: Optional[dict] = None,
     loss_fn: Optional[callable] = None,
 ) -> keras.Model:
@@ -112,6 +137,11 @@ def create_network(
     :param dropout_prop: Dropout proportion for middle dropout layer,
         defaults to 0.25.
     :type dropout_prop: float, optional
+    :param pca_components: If set, prepend a linear projection layer named
+        "pca_projection" of this width as the first layer. The caller is
+        responsible for initializing its weights with PCA loadings. Defaults
+        to None (no projection layer).
+    :type pca_components: int, optional
     :param optimizer_config: Configuration for the optimizer. Should be a dict containing keys:
         "algo" (str): "adam" or "adamw";
         "learning_rate" (float);
@@ -132,8 +162,16 @@ def create_network(
     # Create input layer explicitly
     inputs = keras.Input(shape=(input_shape,))
 
-    # Batch normalization on input
-    x = layers.BatchNormalization()(inputs)
+    # Optional PCA-initialized linear projection as the first layer. Placed
+    # before BatchNormalization so it sees raw genotype counts, which lets a
+    # caller set its weights to PCA loadings and reproduce PCA scores exactly.
+    if pca_components is not None:
+        x = layers.Dense(pca_components, activation="linear", name=PCA_LAYER_NAME)(
+            inputs
+        )
+        x = layers.BatchNormalization()(x)
+    else:
+        x = layers.BatchNormalization()(inputs)
 
     # First half of layers
     for i in range(int(np.floor(n_layers / 2))):
@@ -157,17 +195,11 @@ def create_network(
     if optimizer_config is None:
         optimizer = "Adam"
     else:
-        if optimizer_config["algo"].lower() == "adam":
-            optimizer = keras.optimizers.Adam(
-                learning_rate=optimizer_config["learning_rate"]
-            )
-        elif optimizer_config["algo"].lower() == "adamw":
-            optimizer = keras.optimizers.AdamW(
-                learning_rate=optimizer_config["learning_rate"],
-                weight_decay=optimizer_config["weight_decay"],
-            )
-        else:
-            raise ValueError(f"Unsupported optimizer: {optimizer_config['algo']}")
+        optimizer = build_optimizer(
+            optimizer_config["algo"],
+            optimizer_config["learning_rate"],
+            optimizer_config.get("weight_decay", 0.004),
+        )
 
     # Use provided loss function if available; else default to euclidean_distance_loss
     if loss_fn is None:
@@ -180,6 +212,8 @@ def create_network(
 
 
 __all__ = [
+    "PCA_LAYER_NAME",
+    "build_optimizer",
     "create_network",
     "euclidean_distance_loss",
     "loss_with_range_penalty",

--- a/locator/pca.py
+++ b/locator/pca.py
@@ -1,0 +1,35 @@
+"""PCA loadings for the optional PCA-initialized projection layer."""
+
+import numpy as np
+from sklearn.decomposition import PCA
+
+
+def compute_pca_projection(genotype_matrix, n_components):
+    """Fit PCA and return weights for a linear layer that maps raw genotype
+    counts to PCA scores.
+
+    The returned ``(W, bias)`` satisfy ``X @ W + bias == (X - mean) @ W`` for
+    raw genotype counts ``X``, so a ``Dense`` layer initialized with them
+    reproduces ``PCA.transform(X)`` exactly without pre-centering the input.
+
+    Parameters
+    ----------
+    genotype_matrix : np.ndarray
+        Genotype matrix of shape ``(n_samples, n_snps)``. Pass training
+        samples only to avoid leaking held-out samples into the subspace.
+    n_components : int
+        Number of PCA components (the projection width).
+
+    Returns
+    -------
+    W : np.ndarray
+        Loadings of shape ``(n_snps, n_components)``, float32.
+    bias : np.ndarray
+        Bias of shape ``(n_components,)``, float32, equal to ``-(mean @ W)``.
+    """
+    X = np.asarray(genotype_matrix, dtype=np.float32)
+    pca = PCA(n_components=n_components)
+    pca.fit(X)
+    W = pca.components_.T
+    bias = -(pca.mean_ @ W)
+    return W.astype(np.float32), bias.astype(np.float32)

--- a/locator/training.py
+++ b/locator/training.py
@@ -18,7 +18,15 @@ from .data import (
 )
 from .data import filter_snps_legacy as filter_snps
 from .gpu_optimizer import GPUOptimizer
-from .models import create_network, loss_with_range_penalty, rasterize_species_range
+from .models import (
+    PCA_LAYER_NAME,
+    build_optimizer,
+    create_network,
+    euclidean_distance_loss,
+    loss_with_range_penalty,
+    rasterize_species_range,
+)
+from .pca import compute_pca_projection
 from .sample_weights import weight_samples
 
 
@@ -213,6 +221,14 @@ class TrainingMixin:
         # Store samples and site_order
         self.samples = samples
         self.site_order = site_order
+
+        if self.config.get("pca_components") is not None and (
+            train_gen is not None or site_order is not None
+        ):
+            raise ValueError(
+                "pca_components is not supported with bootstrap/jacknife "
+                "resampling (pre-processed train_gen or site_order)."
+            )
 
         # Use instance default if na_action not specified
         if na_action is None:
@@ -595,17 +611,64 @@ class TrainingMixin:
                     penalty_weight=self.config.get("penalty_weight", 1.0),
                 )
 
-        return create_network(
+        self._loss_fn = loss_fn
+
+        pca_components = self.config.get("pca_components")
+        model = create_network(
             input_shape=input_shape,
             width=self.config.get("width", 256),
             n_layers=self.config.get("nlayers", 8),
             dropout_prop=self.config.get("dropout_prop", 0.25),
+            pca_components=pca_components,
             optimizer_config={
                 "algo": self.config.get("optimizer_algo", "adam"),
                 "learning_rate": self.config.get("learning_rate", 0.001),
                 "weight_decay": self.config.get("weight_decay", 0.004),
             },
             loss_fn=loss_fn,
+        )
+
+        if pca_components is not None:
+            self._inject_pca_weights(model, pca_components)
+
+        return model
+
+    def _inject_pca_weights(self, model, pca_components):
+        """Initialize the pca_projection layer with PCA loadings and freeze it.
+
+        PCA is fit on the training split only. Recompiling is required for the
+        freeze to take effect before phase-1 training. When training data is
+        not available (e.g. building an architecture to load saved weights
+        into), this is a no-op and the layer keeps its loaded weights.
+
+        Args:
+            model: The model returned by create_network with a pca_projection
+                layer.
+            pca_components: Projection width.
+        """
+        index_set = getattr(self, "index_set", None)
+        filtered = getattr(self, "filtered_genotypes", None)
+        if index_set is None or filtered is None:
+            return
+
+        n_snps = filtered.shape[0]
+        train_idx = index_set.train
+        n_train = len(train_idx)
+        if pca_components > min(n_train, n_snps):
+            raise ValueError(
+                f"pca_components ({pca_components}) cannot exceed "
+                f"min(n_train={n_train}, n_snps={n_snps})"
+            )
+
+        train_geno = np.asarray(filtered[:, train_idx].T, dtype=np.float32)
+        W, bias = compute_pca_projection(train_geno, pca_components)
+
+        projection = model.get_layer(PCA_LAYER_NAME)
+        projection.set_weights([W, bias])
+        projection.trainable = False
+        model.compile(
+            optimizer=model.optimizer,
+            loss=self._loss_fn if self._loss_fn is not None else euclidean_distance_loss,
         )
 
     def train_window(
@@ -632,6 +695,12 @@ class TrainingMixin:
         -------
             keras.callbacks.History object from model training
         """
+        if self.config.get("pca_components") is not None:
+            raise ValueError(
+                "pca_components is not supported with windowed analysis; "
+                "run windows without the PCA-init projection."
+            )
+
         # Store samples and index set
         self.samples = samples
         self.index_set = index_set
@@ -871,15 +940,77 @@ class TrainingMixin:
             site_order=site_order,
         )
 
-        history = self.model.fit(
+        self.history = self._fit_model(
+            self.model, train_dataset, val_dataset, callbacks, keras_verbose
+        )
+        return self.history
+
+    def _fit_model(self, model, train_dataset, val_dataset, callbacks, keras_verbose):
+        """Fit a model, running a two-phase PCA fine-tune when enabled.
+
+        With ``pca_components`` set and ``pca_finetune`` true: phase 1 trains
+        with the pca_projection layer frozen at its PCA initialization; phase 2
+        unfreezes it and continues at a low learning rate. Otherwise a single
+        fit runs. Keras resets stateful callbacks (EarlyStopping,
+        ReduceLROnPlateau) at the start of each fit, so the same callback list
+        is reused across both phases.
+
+        Args:
+            model: Compiled Keras model to train.
+            train_dataset: Training tf.data.Dataset.
+            val_dataset: Validation tf.data.Dataset.
+            callbacks: List of Keras callbacks.
+            keras_verbose: Verbosity passed to model.fit.
+
+        Returns
+        -------
+            keras.callbacks.History (phase-2 history with both phases merged
+            when the two-phase fine-tune runs).
+        """
+        max_epochs = self.config.get("max_epochs", 5000)
+        history = model.fit(
             train_dataset,
-            epochs=self.config.get("max_epochs", 5000),
+            epochs=max_epochs,
             validation_data=val_dataset,
             callbacks=callbacks,
             verbose=keras_verbose,
         )
-        self.history = history
-        return history
+
+        pca_components = self.config.get("pca_components")
+        if pca_components is None or not self.config.get("pca_finetune", True):
+            return history
+
+        # Phase 2: unfreeze the PCA projection and fine-tune at a low LR.
+        model.get_layer(PCA_LAYER_NAME).trainable = True
+        model.compile(
+            optimizer=self._make_finetune_optimizer(),
+            loss=getattr(self, "_loss_fn", None) or euclidean_distance_loss,
+        )
+        history2 = model.fit(
+            train_dataset,
+            epochs=max_epochs,
+            validation_data=val_dataset,
+            callbacks=callbacks,
+            verbose=keras_verbose,
+        )
+        return self._concat_histories(history, history2)
+
+    def _make_finetune_optimizer(self):
+        """Build the optimizer for the PCA fine-tuning phase."""
+        return build_optimizer(
+            self.config.get("optimizer_algo", "adam"),
+            self.config.get("pca_finetune_lr", 1e-4),
+            self.config.get("weight_decay", 0.004),
+        )
+
+    @staticmethod
+    def _concat_histories(history1, history2):
+        """Merge two Keras History objects into one covering both phases."""
+        keys = set(history1.history) & set(history2.history)
+        history2.history = {
+            k: list(history1.history[k]) + list(history2.history[k]) for k in keys
+        }
+        return history2
 
     def _save_training_artifacts(self, boot=0, save=True):
         """Save training history and model metadata to disk.

--- a/tests/test_pca_init.py
+++ b/tests/test_pca_init.py
@@ -1,0 +1,108 @@
+"""Tests for the PCA-initialized projection + two-phase fine-tune mode."""
+
+import numpy as np
+import pytest
+from sklearn.decomposition import PCA
+
+from locator import Locator
+from locator.models import PCA_LAYER_NAME
+from locator.pca import compute_pca_projection
+
+
+def _pca_config(basic_config, **overrides):
+    """Base config for a fast, deterministic CPU training run."""
+    config = {
+        **basic_config,
+        "min_mac": 0,
+        "use_mixed_precision": False,
+        "disable_gpu": True,
+    }
+    config.update(overrides)
+    return config
+
+
+def test_compute_pca_projection_matches_sklearn():
+    """A Dense layer with the returned weights reproduces PCA.transform."""
+    rng = np.random.default_rng(0)
+    X = rng.integers(0, 3, size=(30, 80)).astype(np.float32)
+    n_components = 5
+
+    W, bias = compute_pca_projection(X, n_components)
+    assert W.shape == (80, n_components)
+    assert bias.shape == (n_components,)
+
+    reference = (
+        PCA(n_components=n_components)
+        .fit(X.astype(np.float64))
+        .transform(X.astype(np.float64))
+    )
+    projected = X @ W + bias
+    assert np.allclose(projected, reference, atol=1e-2)
+
+
+def test_train_builds_pca_projection(genotype_data, basic_config):
+    """Setting pca_components inserts a pca_projection layer of that width."""
+    genotypes, samples, _, _, _ = genotype_data
+    loc = Locator(_pca_config(basic_config, pca_components=8, max_epochs=2))
+    loc.train(genotypes=genotypes, samples=samples)
+
+    layer = loc.model.get_layer(PCA_LAYER_NAME)
+    assert layer.units == 8
+
+
+def test_frozen_projection_keeps_pca_loadings(genotype_data, basic_config):
+    """With pca_finetune=False the projection stays at its PCA initialization."""
+    genotypes, samples, _, _, _ = genotype_data
+    loc = Locator(
+        _pca_config(basic_config, pca_components=8, max_epochs=3, pca_finetune=False)
+    )
+    loc.train(genotypes=genotypes, samples=samples)
+
+    kernel = loc.model.get_layer(PCA_LAYER_NAME).get_weights()[0]
+    train_geno = np.asarray(
+        loc.filtered_genotypes[:, loc.index_set.train].T, dtype=np.float32
+    )
+    expected, _ = compute_pca_projection(train_geno, 8)
+    assert np.allclose(kernel, expected, atol=1e-5)
+
+
+def test_finetune_moves_projection(genotype_data, basic_config):
+    """With pca_finetune=True phase 2 moves the projection off the PCA init."""
+    genotypes, samples, _, _, _ = genotype_data
+    loc = Locator(
+        _pca_config(basic_config, pca_components=8, max_epochs=5, pca_finetune=True)
+    )
+    loc.train(genotypes=genotypes, samples=samples)
+
+    kernel = loc.model.get_layer(PCA_LAYER_NAME).get_weights()[0]
+    train_geno = np.asarray(
+        loc.filtered_genotypes[:, loc.index_set.train].T, dtype=np.float32
+    )
+    pca_loadings, _ = compute_pca_projection(train_geno, 8)
+    assert not np.allclose(kernel, pca_loadings, atol=1e-6)
+
+
+def test_pca_components_too_large_raises(genotype_data, basic_config):
+    """pca_components exceeding min(n_train, n_snps) raises a clear error."""
+    genotypes, samples, _, _, _ = genotype_data
+    loc = Locator(_pca_config(basic_config, pca_components=999, max_epochs=1))
+    with pytest.raises(ValueError, match="pca_components"):
+        loc.train(genotypes=genotypes, samples=samples)
+
+
+def test_no_pca_projection_when_disabled(genotype_data, basic_config):
+    """Without pca_components the model has no pca_projection layer."""
+    genotypes, samples, _, _, _ = genotype_data
+    loc = Locator(_pca_config(basic_config, max_epochs=1))
+    loc.train(genotypes=genotypes, samples=samples)
+
+    layer_names = [layer.name for layer in loc.model.layers]
+    assert PCA_LAYER_NAME not in layer_names
+
+
+def test_pca_components_rejects_site_order(genotype_data, basic_config):
+    """pca_components is incompatible with bootstrap/jacknife SNP resampling."""
+    genotypes, samples, _, _, n_snps = genotype_data
+    loc = Locator(_pca_config(basic_config, pca_components=8, max_epochs=1))
+    with pytest.raises(ValueError, match="bootstrap"):
+        loc.train(genotypes=genotypes, samples=samples, site_order=np.arange(n_snps))

--- a/tests/test_pca_init.py
+++ b/tests/test_pca_init.py
@@ -100,6 +100,25 @@ def test_no_pca_projection_when_disabled(genotype_data, basic_config):
     assert PCA_LAYER_NAME not in layer_names
 
 
+def test_pca_projection_is_float32_under_mixed_precision():
+    """The pca_projection layer stays float32 even under a mixed_float16 policy.
+
+    Its forward pass nearly cancels two large terms, so float16 would destroy
+    the PCA scores.
+    """
+    from tensorflow import keras
+
+    from locator.models import create_network
+
+    original = keras.mixed_precision.global_policy()
+    keras.mixed_precision.set_global_policy("mixed_float16")
+    try:
+        model = create_network(input_shape=200, pca_components=8)
+        assert model.get_layer(PCA_LAYER_NAME).compute_dtype == "float32"
+    finally:
+        keras.mixed_precision.set_global_policy(original)
+
+
 def test_pca_components_rejects_site_order(genotype_data, basic_config):
     """pca_components is incompatible with bootstrap/jacknife SNP resampling."""
     genotypes, samples, _, _, n_snps = genotype_data


### PR DESCRIPTION
## Summary

For datasets where SNPs greatly outnumber samples, locator's first `Dense(n_SNPs -> width)` layer overfits and prediction error grows *worse* as more SNPs are added. This adds an opt-in training mode that fixes that.

Setting `pca_components` inserts a PCA-initialized linear projection as the network's first layer and fine-tunes it in two phases:

- **phase 1** -- projection frozen at its PCA loadings, train the rest at the normal learning rate
- **phase 2** -- unfreeze the projection, continue at a low learning rate (`pca_finetune_lr`, default 1e-4)

`pca_finetune=False` skips phase 2, leaving a permanently frozen PCA projection (plain PCA preprocessing).

## Details

- New `locator/pca.py`: `compute_pca_projection` returns `(W, bias)` so a linear `Dense` reproduces PCA scores directly from raw genotype counts -- no input pre-centering needed.
- `create_network` gains a `pca_components` parameter; the projection layer is placed before `BatchNormalization` so it sees raw counts. The no-PCA path is unchanged.
- The `pca_projection` layer is pinned to `float32`. It computes `raw_counts @ loadings + bias`, where the two terms are large and nearly cancel to the much smaller PCA score; under the default `mixed_float16` policy that cancellation would lose most of the result.
- PCA is fit **per fold on training samples only** to avoid leaking held-out samples into the projection subspace.
- Available for `train`, `train_holdout` (and the Ray k-fold/LOO/holdout dispatchers), and the k-fold ensemble path -- all funnel through shared `_create_model` + `_fit_model` helpers.
- Explicitly rejected for windowed analysis and bootstrap/jacknife SNP resampling, which are incompatible with a fixed projection.
- New config keys: `pca_components`, `pca_finetune`, `pca_finetune_lr`. New CLI flags: `--pca_components`, `--no_pca_finetune`, `--pca_finetune_lr`.

## Verification (Actinemys WGS 10x, 500k SNPs, k=10)

Clean k-fold comparison through the real `train_holdout` path, with the train/val split and weight init seeded per fold so configs are directly comparable:

| config | median error |
|---|---:|
| raw 500k SNPs (no PCA) | 78.9 km |
| pca-init, frozen, float32 | 48.1 km |
| pca-init, frozen, mixed precision | 45.9 km |
| pca-init, two-phase, float32 | 43.9 km |
| **pca-init, two-phase, mixed precision (default)** | **43.6 km** |

- PCA-init cuts median error ~45% vs the raw 500k baseline in the same harness.
- Results match between mixed precision and float32, confirming the float32 projection layer is sufficient.
- The two-phase fine-tune is a real (modest) gain over the frozen projection.

## Test plan

- [x] New `tests/test_pca_init.py` (8 tests): injected layer reproduces sklearn PCA scores; `train()` builds the projection layer; phase 2 moves the projection while `pca_finetune=False` keeps it frozen at the PCA init; oversized `pca_components` raises; disabled = no layer; resampling combos rejected; projection layer stays float32 under a `mixed_float16` policy.
- [x] Full existing suite green (260 passed, 1 skipped) -- no regression from the `_build_datasets_and_fit` / ensemble refactor.
- [x] Real-data GPU k-fold verification (table above).
