### PR TITLE
GPU-resident genotype loader and per-fold setup speedups

### DIFF
--- a/locator/analysis/holdout.py
+++ b/locator/analysis/holdout.py
@@ -8,6 +8,7 @@ from tensorflow import keras
 from tqdm import tqdm
 
 from ..data import IndexSet
+from ..models import feature_network
 
 
 class HoldoutMixin:
@@ -353,11 +354,11 @@ class HoldoutMixin:
                     2, af[i], size=holdout_gen_modified.shape[0]
                 )
 
-            # Get predictions. holdout_gen_modified is a per-sample genotype
-            # array (sites randomly resampled), so it is fed to the inner
-            # network directly rather than gathered from the resident table.
-            inner = getattr(self.model, "inner", self.model)
-            predictions = inner.predict(holdout_gen_modified, verbose=0)
+            # holdout_gen_modified is a per-sample genotype array with sites
+            # randomly resampled, so it is fed to the feature network directly.
+            predictions = feature_network(self.model).predict(
+                holdout_gen_modified, verbose=0
+            )
 
             # Denormalize
             predictions[:, 0] = predictions[:, 0] * self.sdlong + self.meanlong

--- a/locator/analysis/holdout.py
+++ b/locator/analysis/holdout.py
@@ -353,8 +353,11 @@ class HoldoutMixin:
                     2, af[i], size=holdout_gen_modified.shape[0]
                 )
 
-            # Get predictions
-            predictions = self.model.predict(holdout_gen_modified, verbose=0)
+            # Get predictions. holdout_gen_modified is a per-sample genotype
+            # array (sites randomly resampled), so it is fed to the inner
+            # network directly rather than gathered from the resident table.
+            inner = getattr(self.model, "inner", self.model)
+            predictions = inner.predict(holdout_gen_modified, verbose=0)
 
             # Denormalize
             predictions[:, 0] = predictions[:, 0] * self.sdlong + self.meanlong

--- a/locator/core.py
+++ b/locator/core.py
@@ -328,6 +328,12 @@ class Locator(
             self.positions = None  # For windowed analysis
         self.unnormedlocs = None  # For calculating sample weights
         self.sample_weights = None
+        # GPU-resident genotype table (see IndexedGenotypeModel) built lazily
+        # and reused across folds; _genotype_table_src records which
+        # filtered_genotypes array it was built from so it can be rebuilt when
+        # the underlying data changes (e.g. per window in windowed analysis).
+        self._genotype_table = None
+        self._genotype_table_src = None
 
         # Store na_action as instance attribute for convenience
         self.na_action = self.config["na_action"]

--- a/locator/data/__init__.py
+++ b/locator/data/__init__.py
@@ -12,7 +12,12 @@ from .filters import (
     normalize_locs_params,
 )
 from .indexset import IndexSet
-from .tf_dataset import flip_genotypes_tf, make_tf_dataset, make_tf_dataset_from_arrays
+from .tf_dataset import (
+    build_genotype_table,
+    flip_genotypes_tf,
+    make_tf_dataset,
+    make_tf_dataset_from_arrays,
+)
 from .windows import generate_genomic_windows
 
 __all__ = [
@@ -26,6 +31,7 @@ __all__ = [
     "normalize_locs",
     "normalize_locs_params",
     "IndexSet",
+    "build_genotype_table",
     "make_tf_dataset",
     "make_tf_dataset_from_arrays",
     "flip_genotypes_tf",

--- a/locator/data/tf_dataset.py
+++ b/locator/data/tf_dataset.py
@@ -16,8 +16,8 @@ def build_genotype_table(filtered_genotypes: np.ndarray) -> tf.Tensor:
     The genotype matrix for realistic runs is small enough to live on the GPU
     for the whole run -- its size is ``n_snps * n_samples * dtype_bytes``
     (e.g. 1M x 236 int8 ~= 236 MB, 2M x 236 int8 ~= 472 MB, 4x that for float32
-    dosage). Building it once and gathering rows on-device removes the per-fold
-    re-materialisation and per-epoch host-to-device copies of the old pipeline.
+    dosage). Holding it on-device lets the model gather genotype batches by
+    sample index without any host-to-device traffic during training.
 
     Args:
         filtered_genotypes: Filtered genotype matrix of shape
@@ -46,7 +46,7 @@ def make_tf_dataset(
     batch_size: int = 256,
     sample_weights: Optional[np.ndarray] = None,
     training: bool = True,
-    shuffle_buffer: int = 1024,
+    shuffle: bool = True,
     drop_remainder: Optional[bool] = None,
     prefetch: bool = True,
 ) -> tf.data.Dataset:
@@ -65,7 +65,7 @@ def make_tf_dataset(
         sample_weights: Optional per-sample weights, aligned to the split's
             index order (length must equal the split size).
         training: Whether this is for training (enables shuffling).
-        shuffle_buffer: Non-zero enables shuffling when ``training`` is True.
+        shuffle: Whether to shuffle the split each epoch (only when training).
         drop_remainder: Whether to drop the final partial batch
             (defaults to the value of ``training``).
         prefetch: Whether to prefetch batches.
@@ -97,7 +97,9 @@ def make_tf_dataset(
     else:
         dataset = tf.data.Dataset.from_tensor_slices((indices, coords))
 
-    if training and shuffle_buffer > 0:
+    if training and shuffle:
+        # The split is a few hundred indices; a full-size buffer is a perfect
+        # shuffle at negligible cost.
         dataset = dataset.shuffle(
             buffer_size=len(indices), reshuffle_each_iteration=True
         )
@@ -145,13 +147,14 @@ def make_tf_dataset_from_arrays(
     val_gen: Optional[np.ndarray] = None,
     val_locs: Optional[np.ndarray] = None,
     batch_size: int = 256,
-    **kwargs,
+    cache: bool = True,
+    prefetch: bool = True,
 ) -> Union[tf.data.Dataset, Tuple[tf.data.Dataset, ...]]:
     """Legacy helper: build feature-based datasets from pre-split arrays.
 
-    Kept for backward compatibility. Unlike :func:`make_tf_dataset` (which is
-    index-based), this yields ``(genotype_features, coordinates)`` batches
-    directly from the supplied sample-major arrays.
+    Unlike :func:`make_tf_dataset` (which is index-based), this yields
+    ``(genotype_features, coordinates)`` batches directly from the supplied
+    sample-major arrays.
 
     Args:
         train_gen: Training genotypes of shape ``(n_train, n_features)``.
@@ -161,14 +164,13 @@ def make_tf_dataset_from_arrays(
         val_gen: Optional validation genotypes.
         val_locs: Optional validation locations.
         batch_size: Batch size.
-        **kwargs: Accepts ``cache`` and ``prefetch`` flags.
+        cache: Whether to cache each dataset in memory.
+        prefetch: Whether to prefetch batches.
 
     Returns
     -------
         A single dataset, or a tuple of datasets (train, test, val).
     """
-    cache = kwargs.get("cache", True)
-    prefetch = kwargs.get("prefetch", True)
 
     def _build(gen, locs, training):
         ds = tf.data.Dataset.from_tensor_slices(

--- a/locator/data/tf_dataset.py
+++ b/locator/data/tf_dataset.py
@@ -1,8 +1,8 @@
-"""Unified TensorFlow dataset creation with memory-efficient data access."""
+"""Index-based TensorFlow dataset creation for GPU-resident genotype training."""
 
 from __future__ import annotations
 
-from typing import Dict, Optional, Tuple, Union
+from typing import Optional, Tuple, Union
 
 import numpy as np
 import tensorflow as tf
@@ -10,196 +10,119 @@ import tensorflow as tf
 from .indexset import IndexSet
 
 
-def make_tf_dataset(  # noqa: C901
-    genotypes: np.ndarray,
+def build_genotype_table(filtered_genotypes: np.ndarray) -> tf.Tensor:
+    """Build a GPU-resident, sample-major genotype tensor.
+
+    The genotype matrix for realistic runs is small enough to live on the GPU
+    for the whole run -- its size is ``n_snps * n_samples * dtype_bytes``
+    (e.g. 1M x 236 int8 ~= 236 MB, 2M x 236 int8 ~= 472 MB, 4x that for float32
+    dosage). Building it once and gathering rows on-device removes the per-fold
+    re-materialisation and per-epoch host-to-device copies of the old pipeline.
+
+    Args:
+        filtered_genotypes: Filtered genotype matrix of shape
+            ``(n_snps, n_samples)`` -- int8 allele counts for hard calls, or
+            float32 for genotype-likelihood dosage.
+
+    Returns
+    -------
+        A ``tf.Tensor`` of shape ``(n_samples, n_snps)`` with the source dtype
+        preserved, placed on the GPU when one is available.
+    """
+    arr = np.asarray(filtered_genotypes)
+    # Sample-major rows make each sample's SNP vector contiguous, so the
+    # per-batch row gather inside the model is coalesced. The native dtype is
+    # kept (int8 stays int8); the cast to compute dtype happens per batch.
+    sample_major = np.ascontiguousarray(arr.T)
+    device = "/GPU:0" if tf.config.list_physical_devices("GPU") else "/CPU:0"
+    with tf.device(device):
+        return tf.constant(sample_major)
+
+
+def make_tf_dataset(
     coordinates: np.ndarray,
     index_set: IndexSet,
     split: str,
     batch_size: int = 256,
-    shuffle_buffer: int = 1024,
-    augment: Optional[Dict] = None,
     sample_weights: Optional[np.ndarray] = None,
     training: bool = True,
-    cache: bool = True,
-    prefetch: bool = True,
+    shuffle_buffer: int = 1024,
     drop_remainder: Optional[bool] = None,
-    dtype_policy: Optional[str] = None,
-    site_order: Optional[np.ndarray] = None,
+    prefetch: bool = True,
 ) -> tf.data.Dataset:
-    """Create an efficient tf.data pipeline that gathers rows on-the-fly.
+    """Create an index-based tf.data pipeline for training or validation.
 
-    This function creates a memory-efficient TensorFlow dataset that uses
-    tf.gather to access data by indices rather than copying arrays. It
-    provides consistent handling of sample weights, augmentation, and
-    optimization across all training scenarios.
+    The pipeline carries only sample indices and their coordinates -- a few
+    kilobytes per batch. Genotypes are gathered on the GPU inside
+    ``IndexedGenotypeModel``, so the genotype matrix never enters this pipeline
+    and there is no per-epoch host-to-device genotype traffic.
 
     Args:
-        genotypes: Full genotype array of shape (n_snps, n_samples)
-        coordinates: Full coordinate array of shape (n_samples, 2)
-        index_set: IndexSet containing train/val/test/predict indices
-        split: Which split to use ('train', 'val', 'test', 'predict')
-        batch_size: Batch size for the dataset
-        shuffle_buffer: Buffer size for shuffling (only used if training=True)
-        augment: Optional augmentation config dict with 'enabled' and 'flip_rate'
-        sample_weights: Optional array of sample weights (must match split size)
-        training: Whether this is for training (enables shuffling)
-        cache: Whether to cache data in memory
-        prefetch: Whether to use prefetching
-        drop_remainder: Whether to drop incomplete batches (defaults to value of training)
-        dtype_policy: Optional dtype policy ('float32', 'float16', 'mixed_float16')
-        site_order: Optional array of SNP indices for bootstrap resampling
+        coordinates: Full coordinate array of shape ``(n_samples, 2)``.
+        index_set: IndexSet containing the train/val/test/predict splits.
+        split: Which split to use ('train', 'val', 'test', 'predict').
+        batch_size: Batch size for the dataset.
+        sample_weights: Optional per-sample weights, aligned to the split's
+            index order (length must equal the split size).
+        training: Whether this is for training (enables shuffling).
+        shuffle_buffer: Non-zero enables shuffling when ``training`` is True.
+        drop_remainder: Whether to drop the final partial batch
+            (defaults to the value of ``training``).
+        prefetch: Whether to prefetch batches.
 
     Returns
     -------
-        tf.data.Dataset with structure:
-            - Without weights: (features, labels)
-            - With weights: (features, labels, sample_weights)
+        A ``tf.data.Dataset`` yielding ``(sample_index, coordinate)`` batches,
+        or ``(sample_index, coordinate, sample_weight)`` when weights are given.
     """
-    # Get indices for the requested split
-    indices = index_set.get_split(split)
+    indices = np.asarray(index_set.get_split(split))
 
     if len(indices) == 0:
         raise ValueError(f"Split '{split}' has no samples")
 
-    # Determine data type based on policy
-    if dtype_policy is None:
-        policy = tf.keras.mixed_precision.global_policy()
-        compute_dtype = policy.compute_dtype
-    elif dtype_policy == "float16":
-        compute_dtype = tf.float16
-    elif dtype_policy == "mixed_float16":
-        compute_dtype = tf.float16
-    else:
-        compute_dtype = tf.float32
-
-    # Set drop_remainder default
     if drop_remainder is None:
         drop_remainder = training
 
-    # Convert arrays to tensors for efficient access
-    genotypes_tensor = tf.constant(genotypes, dtype=compute_dtype)
-    coordinates_tensor = tf.constant(coordinates, dtype=tf.float32)
+    indices = indices.astype(np.int32)
+    coords = np.asarray(coordinates)[indices].astype(np.float32)
 
-    # Create the base dataset from indices
-    indices_dataset = tf.data.Dataset.from_tensor_slices(indices)
-
-    # Define the data loading function
-    def load_sample(idx):
-        """Load a single sample by index."""
-        # Get genotypes for this sample
-        sample_genotypes = tf.gather(genotypes_tensor, idx, axis=1)
-
-        if site_order is not None:
-            # Bootstrap resampling: reorder SNPs
-            sample_genotypes = tf.gather(sample_genotypes, site_order)
-
-        # Get coordinates
-        sample_coords = tf.gather(coordinates_tensor, idx)
-
-        return sample_genotypes, sample_coords
-
-    # Map indices to data
-    # Use fixed parallelism to avoid excessive forking
-    dataset = indices_dataset.map(
-        load_sample,
-        num_parallel_calls=4,  # Fixed instead of AUTOTUNE to reduce overhead
-        deterministic=not training,
-    )
-
-    # Add sample weights if provided
     if sample_weights is not None:
         if len(sample_weights) != len(indices):
             raise ValueError(
                 f"Sample weights length ({len(sample_weights)}) must match "
                 f"split size ({len(indices)})"
             )
+        weights = np.asarray(sample_weights, dtype=np.float32)
+        dataset = tf.data.Dataset.from_tensor_slices((indices, coords, weights))
+    else:
+        dataset = tf.data.Dataset.from_tensor_slices((indices, coords))
 
-        # Create weights dataset
-        weights_dataset = tf.data.Dataset.from_tensor_slices(
-            tf.constant(sample_weights, dtype=tf.float32)
-        )
-
-        # Zip with main dataset
-        dataset = tf.data.Dataset.zip((dataset, weights_dataset))
-
-        # Restructure to (features, labels, weights)
-        dataset = dataset.map(
-            lambda data_tuple, weight: (data_tuple[0], data_tuple[1], weight),
-            num_parallel_calls=4,  # Fixed instead of AUTOTUNE
-        )
-
-    # Apply caching before any randomness
-    if cache:
-        dataset = dataset.cache()
-
-    # Apply augmentation if enabled
-    if augment and augment.get("enabled", False):
-        flip_rate = augment.get("flip_rate", 0.05)
-
-        if sample_weights is not None:
-            # With weights: (features, labels, weights)
-            def augment_with_weights(features, labels, weights):
-                augmented_features = flip_genotypes_tf(features, flip_rate)
-                return augmented_features, labels, weights
-
-            dataset = dataset.map(
-                augment_with_weights,
-                num_parallel_calls=4,  # Fixed instead of AUTOTUNE
-            )
-        else:
-            # Without weights: (features, labels)
-            def augment_without_weights(features, labels):
-                augmented_features = flip_genotypes_tf(features, flip_rate)
-                return augmented_features, labels
-
-            dataset = dataset.map(
-                augment_without_weights,
-                num_parallel_calls=4,  # Fixed instead of AUTOTUNE
-            )
-
-    # Shuffle if training
     if training and shuffle_buffer > 0:
         dataset = dataset.shuffle(
-            buffer_size=min(shuffle_buffer, len(indices)), reshuffle_each_iteration=True
+            buffer_size=len(indices), reshuffle_each_iteration=True
         )
 
-    # Batch the dataset
     dataset = dataset.batch(batch_size, drop_remainder=drop_remainder)
 
-    # Prefetch for performance
     if prefetch:
         dataset = dataset.prefetch(tf.data.AUTOTUNE)
-
-    # Apply optimization options
-    options = tf.data.Options()
-    options.experimental_distribute.auto_shard_policy = (
-        tf.data.experimental.AutoShardPolicy.DATA
-    )
-    options.experimental_optimization.apply_default_optimizations = True
-    # Disable map parallelization to avoid excessive forking
-    options.experimental_optimization.map_parallelization = False
-    # Use fixed thread pool instead of 0 to prevent process forking
-    options.threading.private_threadpool_size = 4
-    # Limit inter-op parallelism to reduce overhead
-    options.threading.max_intra_op_parallelism = 1
-    dataset = dataset.with_options(options)
 
     return dataset
 
 
 def flip_genotypes_tf(genotypes: tf.Tensor, flip_rate: float = 0.05) -> tf.Tensor:
-    """Randomly flip genotype values with given probability.
+    """Randomly flip genotype values with a given probability.
 
-    This is a TensorFlow implementation of genotype flipping for data
-    augmentation. It randomly flips allele values (0→1, 1→0, 2 stays 2).
+    Randomly flips allele values (0 to 1, 1 to 0); 2 (missing) is never flipped.
+    Used for training-time data augmentation.
 
     Args:
-        genotypes: Tensor of genotype values
-        flip_rate: Probability of flipping each value
+        genotypes: Tensor of genotype values.
+        flip_rate: Probability of flipping each value.
 
     Returns
     -------
-        Augmented genotypes tensor
+        Augmented genotypes tensor.
     """
     # Create random mask
     mask = tf.random.uniform(tf.shape(genotypes)) < flip_rate
@@ -208,7 +131,7 @@ def flip_genotypes_tf(genotypes: tf.Tensor, flip_rate: float = 0.05) -> tf.Tenso
     is_flippable = tf.less(genotypes, 2.0)
     mask = tf.logical_and(mask, is_flippable)
 
-    # Flip: 0→1, 1→0
+    # Flip: 0 to 1, 1 to 0
     flipped = tf.where(mask, 1.0 - genotypes, genotypes)
 
     return flipped
@@ -224,99 +147,46 @@ def make_tf_dataset_from_arrays(
     batch_size: int = 256,
     **kwargs,
 ) -> Union[tf.data.Dataset, Tuple[tf.data.Dataset, ...]]:
-    """Legacy function to create datasets from pre-split arrays.
+    """Legacy helper: build feature-based datasets from pre-split arrays.
 
-    This function provides backward compatibility for code that already
-    has split arrays. It converts them to the new IndexSet format.
+    Kept for backward compatibility. Unlike :func:`make_tf_dataset` (which is
+    index-based), this yields ``(genotype_features, coordinates)`` batches
+    directly from the supplied sample-major arrays.
 
     Args:
-        train_gen: Training genotypes of shape (n_train, n_features)
-        train_locs: Training locations of shape (n_train, 2)
-        test_gen: Optional test genotypes
-        test_locs: Optional test locations
-        val_gen: Optional validation genotypes
-        val_locs: Optional validation locations
-        batch_size: Batch size
-        **kwargs: Additional arguments passed to make_tf_dataset
+        train_gen: Training genotypes of shape ``(n_train, n_features)``.
+        train_locs: Training locations of shape ``(n_train, 2)``.
+        test_gen: Optional test genotypes.
+        test_locs: Optional test locations.
+        val_gen: Optional validation genotypes.
+        val_locs: Optional validation locations.
+        batch_size: Batch size.
+        **kwargs: Accepts ``cache`` and ``prefetch`` flags.
 
     Returns
     -------
-        Single dataset or tuple of datasets (train, test, val)
+        A single dataset, or a tuple of datasets (train, test, val).
     """
-    # Transpose to get (n_features, n_samples) shape expected by make_tf_dataset
-    # n_features = train_gen.shape[1]  # noqa: F841
-    n_train = train_gen.shape[0]
+    cache = kwargs.get("cache", True)
+    prefetch = kwargs.get("prefetch", True)
 
-    # Create combined arrays
-    total_samples = n_train
-    indices_dict = {"train": np.arange(n_train)}
-
-    arrays_list = [train_gen.T]
-    locs_list = [train_locs]
-
-    if test_gen is not None:
-        n_test = test_gen.shape[0]
-        indices_dict["test"] = np.arange(total_samples, total_samples + n_test)
-        arrays_list.append(test_gen.T)
-        locs_list.append(test_locs)
-        total_samples += n_test
-
-    if val_gen is not None:
-        n_val = val_gen.shape[0]
-        indices_dict["val"] = np.arange(total_samples, total_samples + n_val)
-        arrays_list.append(val_gen.T)
-        locs_list.append(val_locs)
-        total_samples += n_val
-
-    # Stack arrays
-    all_genotypes = np.hstack(arrays_list)
-    all_locs = np.vstack(locs_list)
-
-    # Create IndexSet
-    index_set = IndexSet(indices=indices_dict, total_samples=total_samples)
-
-    # Create datasets
-    datasets = []
-
-    # Training dataset
-    train_dataset = make_tf_dataset(
-        genotypes=all_genotypes,
-        coordinates=all_locs,
-        index_set=index_set,
-        split="train",
-        batch_size=batch_size,
-        training=True,
-        **kwargs,
-    )
-    datasets.append(train_dataset)
-
-    # Test dataset if provided
-    if test_gen is not None:
-        test_dataset = make_tf_dataset(
-            genotypes=all_genotypes,
-            coordinates=all_locs,
-            index_set=index_set,
-            split="test",
-            batch_size=batch_size,
-            training=False,
-            shuffle_buffer=0,
-            **kwargs,
+    def _build(gen, locs, training):
+        ds = tf.data.Dataset.from_tensor_slices(
+            (np.asarray(gen, dtype=np.float32), np.asarray(locs, dtype=np.float32))
         )
-        datasets.append(test_dataset)
+        if cache:
+            ds = ds.cache()
+        if training:
+            ds = ds.shuffle(len(gen), reshuffle_each_iteration=True)
+        ds = ds.batch(batch_size, drop_remainder=training)
+        if prefetch:
+            ds = ds.prefetch(tf.data.AUTOTUNE)
+        return ds
 
-    # Validation dataset if provided
+    datasets = [_build(train_gen, train_locs, training=True)]
+    if test_gen is not None:
+        datasets.append(_build(test_gen, test_locs, training=False))
     if val_gen is not None:
-        val_dataset = make_tf_dataset(
-            genotypes=all_genotypes,
-            coordinates=all_locs,
-            index_set=index_set,
-            split="val",
-            batch_size=batch_size,
-            training=False,
-            shuffle_buffer=0,
-            **kwargs,
-        )
-        datasets.append(val_dataset)
+        datasets.append(_build(val_gen, val_locs, training=False))
 
-    # Return single dataset or tuple
     return datasets[0] if len(datasets) == 1 else tuple(datasets)

--- a/locator/ensemble_mixin.py
+++ b/locator/ensemble_mixin.py
@@ -294,9 +294,12 @@ class EnsembleMixin:
             "sdlat": sdlat,
         }
 
-        # Expose the fold's split so _create_model can fit per-fold PCA on the
-        # training samples when pca_components is enabled.
+        # Expose the fold's split and genotypes so _create_model can build the
+        # IndexedGenotypeModel (and fit per-fold PCA when pca_components is set).
+        # The parallel ensemble actor calls this method directly, bypassing
+        # train_ensemble, so filtered_genotypes must be set here too.
         self.index_set = index_set
+        self.filtered_genotypes = filtered_genotypes
 
         # Create model
         model = self._create_model(input_shape=filtered_genotypes.shape[0])
@@ -313,26 +316,22 @@ class EnsembleMixin:
         # Determine optimal batch size for ensemble
         batch_size = self.get_ensemble_batch_size(len(train_idx), fold_idx)
 
-        # Create datasets
+        # Create datasets. Augmentation is applied inside the model (configured
+        # via self.config["augmentation"] in train_ensemble), not the pipeline.
         train_dataset = make_tf_dataset(
-            genotypes=filtered_genotypes,
             coordinates=normalized_locs,
             index_set=index_set,
             split="train",
             batch_size=batch_size,
-            augment=augment_config,
             training=True,
-            cache=True,
         )
 
         val_dataset = make_tf_dataset(
-            genotypes=filtered_genotypes,
             coordinates=normalized_locs,
             index_set=index_set,
             split="test",  # k-fold uses 'test' for validation
             batch_size=batch_size,
             training=False,
-            cache=True,
         )
 
         # Create callbacks for this fold
@@ -475,18 +474,14 @@ class EnsembleMixin:
 
     def _predict_single_fold(self, model_info, filtered_genotypes, samples, indices):
         """Make predictions using a single fold model."""
-        # Load model weights if needed
         model = model_info["model"]
+        inner = getattr(model, "inner", model)
         if model_info["weights_file"]:
-            model.load_weights(model_info["weights_file"])
+            inner.load_weights(model_info["weights_file"])
 
-        # Create prediction dataset
-        pred_dataset = self._create_prediction_dataset(
-            filtered_genotypes, samples, indices
-        )
-
-        # Make predictions
-        predictions = model.predict(pred_dataset, verbose=0)
+        # Predict on the sample-major genotype slice for the target indices.
+        pred_array = np.ascontiguousarray(filtered_genotypes[:, indices].T)
+        predictions = inner.predict(pred_array, verbose=0)
 
         # Denormalize using NormalizationParams
         norm_params = NormalizationParams(
@@ -497,29 +492,6 @@ class EnsembleMixin:
         )
 
         return norm_params.reverse(predictions)
-
-    def _create_prediction_dataset(self, filtered_genotypes, samples, indices):
-        """Create tf.data dataset for prediction."""
-        # Create IndexSet for prediction
-        pred_index_set = IndexSet.from_manual(
-            train=np.array([], dtype=int),
-            test=indices,
-            total_samples=len(samples),
-        )
-
-        # Create dummy coordinates (not used in prediction)
-        dummy_coords = np.zeros((len(samples), 2))
-
-        # Create and return dataset
-        return make_tf_dataset(
-            genotypes=filtered_genotypes,
-            coordinates=dummy_coords,
-            index_set=pred_index_set,
-            split="test",
-            batch_size=self.config.get("batch_size", 32),
-            training=False,
-            cache=False,
-        )
 
     def _format_ensemble_predictions_df(
         self,
@@ -665,14 +637,11 @@ class EnsembleMixin:
             model = self._ensemble_model_manager.get_model(
                 fold_idx, filtered_genotypes.shape[0]
             )
+            inner = getattr(model, "inner", model)
 
-            # Create prediction dataset
-            pred_dataset = self._create_prediction_dataset(
-                filtered_genotypes, samples, indices
-            )
-
-            # Make predictions
-            predictions = model.predict(pred_dataset, verbose=0)
+            # Predict on the sample-major genotype slice for the target indices.
+            pred_array = np.ascontiguousarray(filtered_genotypes[:, indices].T)
+            predictions = inner.predict(pred_array, verbose=0)
 
             # Get normalization params for this fold
             norm_params = self._ensemble_model_manager.get_normalization_params(fold_idx)
@@ -753,7 +722,7 @@ class EnsembleMixin:
             # Only compute for first fold, reuse for others
             if fold_idx == 0 and hasattr(self, "model") and self.model is not None:
                 batch_size = GPUOptimizer.get_optimal_batch_size(
-                    model=self.model,
+                    model=getattr(self.model, "inner", self.model),
                     input_shape=(self.filtered_genotypes.shape[0],),
                     dataset_size=dataset_size,
                     verbose=self.config.get("keras_verbose", 1) > 0,

--- a/locator/ensemble_mixin.py
+++ b/locator/ensemble_mixin.py
@@ -9,6 +9,8 @@ from tensorflow import keras
 from .data import IndexSet, NormalizationParams, make_tf_dataset, normalize_locs
 from .ensemble_model_manager import EnsembleModelManager
 from .gpu_optimizer import GPUOptimizer
+from .models import feature_network
+from .prediction import predict_on_indices
 
 # from tqdm import tqdm
 
@@ -475,13 +477,10 @@ class EnsembleMixin:
     def _predict_single_fold(self, model_info, filtered_genotypes, samples, indices):
         """Make predictions using a single fold model."""
         model = model_info["model"]
-        inner = getattr(model, "inner", model)
         if model_info["weights_file"]:
-            inner.load_weights(model_info["weights_file"])
+            feature_network(model).load_weights(model_info["weights_file"])
 
-        # Predict on the sample-major genotype slice for the target indices.
-        pred_array = np.ascontiguousarray(filtered_genotypes[:, indices].T)
-        predictions = inner.predict(pred_array, verbose=0)
+        predictions = predict_on_indices(model, filtered_genotypes, indices)
 
         # Denormalize using NormalizationParams
         norm_params = NormalizationParams(
@@ -637,11 +636,7 @@ class EnsembleMixin:
             model = self._ensemble_model_manager.get_model(
                 fold_idx, filtered_genotypes.shape[0]
             )
-            inner = getattr(model, "inner", model)
-
-            # Predict on the sample-major genotype slice for the target indices.
-            pred_array = np.ascontiguousarray(filtered_genotypes[:, indices].T)
-            predictions = inner.predict(pred_array, verbose=0)
+            predictions = predict_on_indices(model, filtered_genotypes, indices)
 
             # Get normalization params for this fold
             norm_params = self._ensemble_model_manager.get_normalization_params(fold_idx)
@@ -722,7 +717,7 @@ class EnsembleMixin:
             # Only compute for first fold, reuse for others
             if fold_idx == 0 and hasattr(self, "model") and self.model is not None:
                 batch_size = GPUOptimizer.get_optimal_batch_size(
-                    model=getattr(self.model, "inner", self.model),
+                    model=feature_network(self.model),
                     input_shape=(self.filtered_genotypes.shape[0],),
                     dataset_size=dataset_size,
                     verbose=self.config.get("keras_verbose", 1) > 0,

--- a/locator/models.py
+++ b/locator/models.py
@@ -340,11 +340,22 @@ class IndexedGenotypeModel(keras.Model):
         return self.inner.load_weights(*args, **kwargs)
 
 
+def feature_network(model):
+    """Return the network that consumes genotype features.
+
+    Prediction and batch-size probing feed genotype features directly; given
+    either an IndexedGenotypeModel or a plain network, return the one that
+    takes ``(batch, n_snps)`` input.
+    """
+    return model.inner if isinstance(model, IndexedGenotypeModel) else model
+
+
 __all__ = [
     "PCA_LAYER_NAME",
     "PCA_GATE_NAME",
     "GradientGate",
     "IndexedGenotypeModel",
+    "feature_network",
     "build_optimizer",
     "create_network",
     "euclidean_distance_loss",

--- a/locator/models.py
+++ b/locator/models.py
@@ -12,6 +12,7 @@ from tensorflow.keras import backend as K
 from tensorflow.keras import layers
 
 PCA_LAYER_NAME = "pca_projection"
+PCA_GATE_NAME = "pca_finetune_gate"
 
 
 def build_optimizer(algo, learning_rate, weight_decay=0.004):
@@ -116,6 +117,38 @@ def loss_with_range_penalty(
     return euclidean + penalty_weight * penalty
 
 
+class GradientGate(keras.layers.Layer):
+    """Pass values through unchanged while scaling the gradient by a gate.
+
+    Lets the PCA-initialized projection switch between frozen (phase 1) and
+    fine-tuning (phase 2) without changing the training graph. The layer's
+    output value is always its input, but the gradient that reaches the input
+    -- and therefore the upstream projection's weights -- is multiplied by
+    ``gate``: 0 holds the projection at its PCA initialization, 1 lets it
+    train. ``gate`` is a non-trainable variable, so flipping it neither
+    retraces nor recompiles the graph, which keeps the compiled training
+    function reusable across both phases and across folds.
+    """
+
+    def build(self, input_shape):
+        """Create the non-trainable gate variable (starts closed, at 0)."""
+        self.gate = self.add_weight(
+            name="gate",
+            shape=(),
+            initializer="zeros",
+            trainable=False,
+            dtype="float32",
+        )
+        super().build(input_shape)
+
+    def call(self, inputs):
+        """Return the input value with its gradient scaled by the gate."""
+        # gate == 0: output value == inputs, gradient to inputs == 0.
+        # gate == 1: output == inputs with the full gradient.
+        frozen = tf.stop_gradient(inputs)
+        return frozen + self.gate * (inputs - frozen)
+
+
 def create_network(
     input_shape: int,
     width: int = 256,
@@ -174,6 +207,9 @@ def create_network(
             name=PCA_LAYER_NAME,
             dtype="float32",
         )(inputs)
+        # Gradient gate: switches the projection between frozen and fine-tuning
+        # by flipping a variable, so the training graph never changes.
+        x = GradientGate(name=PCA_GATE_NAME, dtype="float32")(x)
         x = layers.BatchNormalization()(x)
     else:
         x = layers.BatchNormalization()(inputs)
@@ -297,6 +333,8 @@ class IndexedGenotypeModel(keras.Model):
 
 __all__ = [
     "PCA_LAYER_NAME",
+    "PCA_GATE_NAME",
+    "GradientGate",
     "IndexedGenotypeModel",
     "build_optimizer",
     "create_network",

--- a/locator/models.py
+++ b/locator/models.py
@@ -305,6 +305,15 @@ class IndexedGenotypeModel(keras.Model):
 
         self._flip_fn = flip_genotypes_tf
 
+    @property
+    def genotype_table(self):
+        """The GPU-resident genotype table this model gathers from.
+
+        The compiled ``call`` captures this tensor by reference, so a model
+        may only be reused while its table is unchanged.
+        """
+        return self._table
+
     def call(self, idx, training=False):
         """Gather genotypes for a batch of sample indices and predict."""
         idx = tf.cast(idx, tf.int32)

--- a/locator/models.py
+++ b/locator/models.py
@@ -216,8 +216,88 @@ def create_network(
     return model
 
 
+class IndexedGenotypeModel(keras.Model):
+    """Model that gathers genotypes from a GPU-resident table by sample index.
+
+    The genotype matrix for realistic runs is small enough to live on the GPU
+    for the entire run (n_snps x n_samples x dtype bytes; sub-GB as int8). This
+    wrapper holds the whole matrix as a GPU-resident, sample-major tensor and
+    makes the model's input a vector of sample indices instead of a genotype
+    batch. Each training step the only host-to-device traffic is the index
+    vector; the row gather, dtype cast, and optional augmentation all run on the
+    GPU, and ``inner`` -- the ordinary coordinate-prediction network -- sees the
+    same ``(batch, n_snps)`` float features it always has.
+
+    The genotype table is held as a plain tensor, never a tracked weight, so it
+    stays out of ``get_weights()`` and checkpoints. ``save_weights`` /
+    ``load_weights`` / ``get_layer`` delegate to ``inner`` so the on-disk weight
+    format and PCA-layer wiring are identical to a bare network.
+
+    Parameters
+    ----------
+    inner : keras.Model
+        Coordinate-prediction network from ``create_network``; consumes
+        ``(batch, n_snps)`` genotype features.
+    genotype_table : tf.Tensor
+        Sample-major genotype matrix, shape ``(n_samples, n_snps)``, native
+        dtype (int8 hard calls or float32 dosage).
+    site_order : array-like or None
+        Optional SNP resampling order (bootstrap/jacknife), applied as a
+        per-batch column gather after the row gather.
+    augment : dict or None
+        Optional augmentation config with ``enabled`` and ``flip_rate`` keys;
+        genotype flipping is applied only during training.
+    """
+
+    def __init__(self, inner, genotype_table, site_order=None, augment=None):
+        super().__init__(name="indexed_genotype_model")
+        self.inner = inner
+        # Deliberately a plain tensor, not a tf.Variable: a Variable attribute
+        # would be tracked by Keras and copied on every get_weights() call
+        # (e.g. by EarlyStopping(restore_best_weights=True)). A constant tensor
+        # is captured by reference into the traced call and stays GPU-resident.
+        self._table = genotype_table
+        self._site_order = (
+            tf.constant(np.asarray(site_order), dtype=tf.int32)
+            if site_order is not None
+            else None
+        )
+        self._augment = augment or {}
+        # Imported here rather than at module scope to keep the models module
+        # free of any import-time dependency on the data subpackage.
+        from .data.tf_dataset import flip_genotypes_tf
+
+        self._flip_fn = flip_genotypes_tf
+
+    def call(self, idx, training=False):
+        """Gather genotypes for a batch of sample indices and predict."""
+        idx = tf.cast(idx, tf.int32)
+        g = tf.gather(self._table, idx, axis=0)  # (batch, n_snps), on GPU
+        if self._site_order is not None:
+            g = tf.gather(g, self._site_order, axis=1)  # bootstrap SNP resample
+        # float32 keeps the optional pca_projection layer (float32, raw counts)
+        # exact; mixed-precision layers inside inner downcast internally.
+        g = tf.cast(g, tf.float32)
+        if training and self._augment.get("enabled", False):
+            g = self._flip_fn(g, self._augment.get("flip_rate", 0.05))
+        return self.inner(g, training=training)
+
+    def get_layer(self, *args, **kwargs):
+        """Delegate so lookups of inner layers (e.g. PCA_LAYER_NAME) resolve."""
+        return self.inner.get_layer(*args, **kwargs)
+
+    def save_weights(self, *args, **kwargs):
+        """Persist only the inner network -- on-disk weight format is unchanged."""
+        return self.inner.save_weights(*args, **kwargs)
+
+    def load_weights(self, *args, **kwargs):
+        """Load weights into the inner network."""
+        return self.inner.load_weights(*args, **kwargs)
+
+
 __all__ = [
     "PCA_LAYER_NAME",
+    "IndexedGenotypeModel",
     "build_optimizer",
     "create_network",
     "euclidean_distance_loss",

--- a/locator/pca.py
+++ b/locator/pca.py
@@ -61,9 +61,11 @@ def compute_pca_projection_gram(genotype_matrix, n_components):
 
     Returns
     -------
-    W : np.ndarray
-        Loadings of shape ``(n_snps, n_components)``, float32.
-    bias : np.ndarray
+    W : tf.Tensor
+        Loadings of shape ``(n_snps, n_components)``, float32. Returned as a
+        device tensor so the caller can assign it to the projection layer
+        without a host round trip.
+    bias : tf.Tensor
         Bias of shape ``(n_components,)``, float32, equal to ``-(mean @ W)``.
     """
     X = tf.cast(genotype_matrix, tf.float32)
@@ -76,8 +78,5 @@ def compute_pca_projection_gram(genotype_matrix, n_components):
     # Guard against tiny negative eigenvalues from float round-off.
     scale = tf.sqrt(tf.maximum(evals, 1e-12))
     W = tf.linalg.matmul(Xc, evecs, transpose_a=True) / scale
-    bias = -tf.linalg.matmul(mean, W)
-    return (
-        W.numpy().astype(np.float32),
-        tf.reshape(bias, [-1]).numpy().astype(np.float32),
-    )
+    bias = tf.reshape(-tf.linalg.matmul(mean, W), [-1])
+    return W, bias

--- a/locator/pca.py
+++ b/locator/pca.py
@@ -1,6 +1,7 @@
 """PCA loadings for the optional PCA-initialized projection layer."""
 
 import numpy as np
+import tensorflow as tf
 from sklearn.decomposition import PCA
 
 
@@ -33,3 +34,50 @@ def compute_pca_projection(genotype_matrix, n_components):
     W = pca.components_.T
     bias = -(pca.mean_ @ W)
     return W.astype(np.float32), bias.astype(np.float32)
+
+
+def compute_pca_projection_gram(genotype_matrix, n_components):
+    """Fit PCA via the Gram-matrix eigendecomposition; a fast path for the
+    PCA-initialized projection layer.
+
+    Returns the same ``(W, bias)`` contract as :func:`compute_pca_projection`,
+    but built entirely from TensorFlow ops, so it runs on the GPU when the
+    input tensor is GPU-resident. With far more SNPs than samples the Gram
+    matrix ``Xc @ Xcᵀ`` is only ``(n_samples, n_samples)``, so the fit reduces
+    to one small eigendecomposition plus two matmuls -- orders of magnitude
+    cheaper than an SVD over the full ``(n_samples, n_snps)`` matrix.
+
+    The Gram matrix's eigenvectors are the left singular vectors of ``Xc`` and
+    its eigenvalues the squared singular values, so the loadings are recovered
+    as ``V = Xcᵀ @ U / singular_value``.
+
+    Parameters
+    ----------
+    genotype_matrix : tf.Tensor or np.ndarray
+        Genotype matrix of shape ``(n_samples, n_snps)``, any numeric dtype.
+        Pass training samples only to avoid leaking held-out samples.
+    n_components : int
+        Number of PCA components (the projection width).
+
+    Returns
+    -------
+    W : np.ndarray
+        Loadings of shape ``(n_snps, n_components)``, float32.
+    bias : np.ndarray
+        Bias of shape ``(n_components,)``, float32, equal to ``-(mean @ W)``.
+    """
+    X = tf.cast(genotype_matrix, tf.float32)
+    mean = tf.reduce_mean(X, axis=0, keepdims=True)
+    Xc = X - mean
+    gram = tf.linalg.matmul(Xc, Xc, transpose_b=True)
+    evals, evecs = tf.linalg.eigh(gram)  # ascending eigenvalues
+    evals = evals[::-1][:n_components]
+    evecs = evecs[:, ::-1][:, :n_components]
+    # Guard against tiny negative eigenvalues from float round-off.
+    scale = tf.sqrt(tf.maximum(evals, 1e-12))
+    W = tf.linalg.matmul(Xc, evecs, transpose_a=True) / scale
+    bias = -tf.linalg.matmul(mean, W)
+    return (
+        W.numpy().astype(np.float32),
+        tf.reshape(bias, [-1]).numpy().astype(np.float32),
+    )

--- a/locator/prediction.py
+++ b/locator/prediction.py
@@ -53,6 +53,10 @@ class PredictionMixin:
         if self.model is None:
             raise ValueError("Model must be trained before prediction")
 
+        # IndexedGenotypeModel gathers genotypes by index for training; for
+        # prediction we feed genotype features straight to the inner network.
+        inner = getattr(self.model, "inner", self.model)
+
         # Check if using new tf.data approach or old array approach
         if genotypes is not None:
             # New tf.data approach
@@ -62,10 +66,6 @@ class PredictionMixin:
                     DeprecationWarning,
                     stacklevel=2,
                 )
-
-            # Import required modules
-            from .data import IndexSet, make_tf_dataset
-            from .data import filter_snps_legacy as filter_snps
 
             # Determine which samples to predict
             locs = None
@@ -142,30 +142,13 @@ class PredictionMixin:
                     impute=self.config.get("impute_missing", False),
                 )
 
-            # Create IndexSet for prediction
-            predict_index_set = IndexSet(
-                indices={"predict": indices},
-                total_samples=len(samples),
-                na_mask=None,  # Not needed for prediction
-            )
+            # Slice the filtered genotype matrix for the target samples and
+            # run the plain network directly (sample-major feature array).
+            pred_array = np.ascontiguousarray(filtered_genotypes[:, indices].T)
+            if site_order is not None:
+                pred_array = pred_array[:, site_order]
 
-            # Create dummy coordinates for prediction (values don't matter)
-            dummy_coords = np.zeros((len(samples), 2))
-
-            # Create prediction dataset
-            predict_dataset = make_tf_dataset(
-                genotypes=filtered_genotypes,  # Use filtered genotypes
-                coordinates=dummy_coords,
-                index_set=predict_index_set,
-                split="predict",
-                batch_size=self.config.get("batch_size", 256),
-                training=False,
-                cache=True,
-                site_order=site_order,
-            )
-
-            # Get predictions
-            predictions = self.model.predict(predict_dataset, verbose=verbose)
+            predictions = inner.predict(pred_array, verbose=verbose)
 
             # Store the indices we predicted on for later use
             prediction_indices = indices
@@ -199,7 +182,7 @@ class PredictionMixin:
                 return empty_df if return_df else None
 
             # Get predictions
-            predictions = self.model.predict(predgen)
+            predictions = inner.predict(predgen)
 
             # Use stored pred_indices
             prediction_indices = (
@@ -460,32 +443,10 @@ class PredictionMixin:
         if verbose:
             print("Predicting locations for holdout samples...")
 
-        # Use tf.data approach for predictions
-        from .data import IndexSet, make_tf_dataset
-
-        # Create IndexSet for holdout samples
-        holdout_index_set = IndexSet(
-            indices={"predict": self.holdout_idx},
-            total_samples=len(self.samples),
-            na_mask=None,
-        )
-
-        # Create dummy coordinates for prediction
-        dummy_coords = np.zeros((len(self.samples), 2))
-
-        # Create prediction dataset
-        predict_dataset = make_tf_dataset(
-            genotypes=self.filtered_genotypes,
-            coordinates=dummy_coords,
-            index_set=holdout_index_set,
-            split="predict",
-            batch_size=self.config.get("batch_size", 256),
-            training=False,
-            cache=True,
-        )
-
-        # Get predictions
-        predictions = self.model.predict(predict_dataset, verbose=verbose)
+        # holdout_gen is the (n_holdout, n_snps) feature slice stored by
+        # train_holdout via _store_holdout_state; predict on it directly.
+        inner = getattr(self.model, "inner", self.model)
+        predictions = inner.predict(self.holdout_gen, verbose=verbose)
 
         # Create output dataframe
         pred_df = pd.DataFrame(predictions, columns=["x", "y"])

--- a/locator/prediction.py
+++ b/locator/prediction.py
@@ -8,6 +8,21 @@ import numpy as np
 import pandas as pd
 
 from .data import filter_dosage_matrix, is_dosage_matrix
+from .models import feature_network
+
+
+def predict_on_indices(model, filtered_genotypes, indices, site_order=None, verbose=0):
+    """Predict coordinates for the given samples from the genotype matrix.
+
+    Slices the requested samples, transposes to sample-major, and runs the
+    network that consumes genotype features -- unwrapping IndexedGenotypeModel
+    when needed.
+    """
+    inner = feature_network(model)
+    features = np.ascontiguousarray(filtered_genotypes[:, indices].T)
+    if site_order is not None:
+        features = features[:, site_order]
+    return inner.predict(features, verbose=verbose)
 
 
 class PredictionMixin:
@@ -54,8 +69,8 @@ class PredictionMixin:
             raise ValueError("Model must be trained before prediction")
 
         # IndexedGenotypeModel gathers genotypes by index for training; for
-        # prediction we feed genotype features straight to the inner network.
-        inner = getattr(self.model, "inner", self.model)
+        # prediction we feed genotype features straight to the feature network.
+        inner = feature_network(self.model)
 
         # Check if using new tf.data approach or old array approach
         if genotypes is not None:
@@ -142,13 +157,13 @@ class PredictionMixin:
                     impute=self.config.get("impute_missing", False),
                 )
 
-            # Slice the filtered genotype matrix for the target samples and
-            # run the plain network directly (sample-major feature array).
-            pred_array = np.ascontiguousarray(filtered_genotypes[:, indices].T)
-            if site_order is not None:
-                pred_array = pred_array[:, site_order]
-
-            predictions = inner.predict(pred_array, verbose=verbose)
+            predictions = predict_on_indices(
+                self.model,
+                filtered_genotypes,
+                indices,
+                site_order=site_order,
+                verbose=verbose,
+            )
 
             # Store the indices we predicted on for later use
             prediction_indices = indices
@@ -444,9 +459,10 @@ class PredictionMixin:
             print("Predicting locations for holdout samples...")
 
         # holdout_gen is the (n_holdout, n_snps) feature slice stored by
-        # train_holdout via _store_holdout_state; predict on it directly.
-        inner = getattr(self.model, "inner", self.model)
-        predictions = inner.predict(self.holdout_gen, verbose=verbose)
+        # _store_holdout_state; predict on it directly.
+        predictions = feature_network(self.model).predict(
+            self.holdout_gen, verbose=verbose
+        )
 
         # Create output dataframe
         pred_df = pd.DataFrame(predictions, columns=["x", "y"])

--- a/locator/training.py
+++ b/locator/training.py
@@ -7,6 +7,7 @@ from datetime import datetime
 import h5py
 import numpy as np
 import pandas as pd
+import tensorflow as tf
 from tensorflow import keras
 
 from .data import (
@@ -28,7 +29,7 @@ from .models import (
     loss_with_range_penalty,
     rasterize_species_range,
 )
-from .pca import compute_pca_projection
+from .pca import compute_pca_projection_gram
 from .sample_weights import weight_samples
 
 
@@ -694,10 +695,12 @@ class TrainingMixin:
     def _inject_pca_weights(self, model, pca_components):
         """Initialize the pca_projection layer with PCA loadings and freeze it.
 
-        PCA is fit on the training split only. Recompiling is required for the
-        freeze to take effect before phase-1 training. When training data is
-        not available (e.g. building an architecture to load saved weights
-        into), this is a no-op and the layer keeps its loaded weights.
+        PCA is fit on the training split only, gathered from the GPU-resident
+        genotype table so the eigendecomposition runs on-device with no host
+        round trip. Recompiling is required for the freeze to take effect
+        before phase-1 training. When training data is not available (e.g.
+        building an architecture to load saved weights into), this is a no-op
+        and the layer keeps its loaded weights.
 
         Args:
             model: The model returned by create_network with a pca_projection
@@ -718,8 +721,14 @@ class TrainingMixin:
                 f"min(n_train={n_train}, n_snps={n_snps})"
             )
 
-        train_geno = np.asarray(filtered[:, train_idx].T, dtype=np.float32)
-        W, bias = compute_pca_projection(train_geno, pca_components)
+        # Gather the training rows from the resident table (sample-major, on
+        # the GPU) and fit PCA there via the Gram-matrix method.
+        train_geno = tf.gather(
+            self._get_genotype_table(),
+            np.asarray(train_idx, dtype=np.int32),
+            axis=0,
+        )
+        W, bias = compute_pca_projection_gram(train_geno, pca_components)
 
         projection = model.get_layer(PCA_LAYER_NAME)
         projection.set_weights([W, bias])

--- a/locator/training.py
+++ b/locator/training.py
@@ -27,6 +27,7 @@ from .models import (
     build_optimizer,
     create_network,
     euclidean_distance_loss,
+    feature_network,
     loss_with_range_penalty,
     rasterize_species_range,
 )
@@ -742,7 +743,11 @@ class TrainingMixin:
         )
         W, bias = compute_pca_projection_gram(train_geno, pca_components)
 
-        model.get_layer(PCA_LAYER_NAME).set_weights([W, bias])
+        # Assign the loadings straight from the device tensors -- set_weights
+        # would round them through host memory.
+        projection = model.get_layer(PCA_LAYER_NAME)
+        projection.kernel.assign(W)
+        projection.bias.assign(bias)
         # Close the gate: phase-1 training holds the projection at its PCA
         # initialization. The layer stays trainable, so the graph is unchanged.
         model.get_layer(PCA_GATE_NAME).gate.assign(0.0)
@@ -862,10 +867,10 @@ class TrainingMixin:
             "disable_gpu", False
         ):
             try:
-                # Probe the inner network: it consumes genotype features, while
-                # the IndexedGenotypeModel wrapper consumes sample indices.
+                # Probe the feature network: the IndexedGenotypeModel wrapper
+                # consumes sample indices, not genotype features.
                 optimal_batch = GPUOptimizer.get_optimal_batch_size(
-                    getattr(self.model, "inner", self.model),
+                    feature_network(self.model),
                     input_shape=(self.filtered_genotypes.shape[0],),
                     target_memory_usage=0.85,
                     dataset_size=dataset_size,

--- a/locator/training.py
+++ b/locator/training.py
@@ -21,6 +21,7 @@ from .data import (
 from .data import filter_snps_legacy as filter_snps
 from .gpu_optimizer import GPUOptimizer
 from .models import (
+    PCA_GATE_NAME,
     PCA_LAYER_NAME,
     IndexedGenotypeModel,
     build_optimizer,
@@ -693,14 +694,15 @@ class TrainingMixin:
         return self._genotype_table
 
     def _inject_pca_weights(self, model, pca_components):
-        """Initialize the pca_projection layer with PCA loadings and freeze it.
+        """Initialize the pca_projection layer with PCA loadings, gate closed.
 
         PCA is fit on the training split only, gathered from the GPU-resident
         genotype table so the eigendecomposition runs on-device with no host
-        round trip. Recompiling is required for the freeze to take effect
-        before phase-1 training. When training data is not available (e.g.
-        building an architecture to load saved weights into), this is a no-op
-        and the layer keeps its loaded weights.
+        round trip. The projection layer stays trainable; phase-1 training is
+        held at the PCA initialization by closing the gradient gate, which
+        needs no recompile. When training data is not available (e.g. building
+        an architecture to load saved weights into), this is a no-op and the
+        layer keeps its loaded weights.
 
         Args:
             model: The model returned by create_network with a pca_projection
@@ -730,13 +732,10 @@ class TrainingMixin:
         )
         W, bias = compute_pca_projection_gram(train_geno, pca_components)
 
-        projection = model.get_layer(PCA_LAYER_NAME)
-        projection.set_weights([W, bias])
-        projection.trainable = False
-        model.compile(
-            optimizer=model.optimizer,
-            loss=self._loss_fn if self._loss_fn is not None else euclidean_distance_loss,
-        )
+        model.get_layer(PCA_LAYER_NAME).set_weights([W, bias])
+        # Close the gate: phase-1 training holds the projection at its PCA
+        # initialization. The layer stays trainable, so the graph is unchanged.
+        model.get_layer(PCA_GATE_NAME).gate.assign(0.0)
 
     def train_window(
         self,
@@ -1011,11 +1010,13 @@ class TrainingMixin:
         """Fit a model, running a two-phase PCA fine-tune when enabled.
 
         With ``pca_components`` set and ``pca_finetune`` true: phase 1 trains
-        with the pca_projection layer frozen at its PCA initialization; phase 2
-        unfreezes it and continues at a low learning rate. Otherwise a single
-        fit runs. Keras resets stateful callbacks (EarlyStopping,
-        ReduceLROnPlateau) at the start of each fit, so the same callback list
-        is reused across both phases.
+        with the projection held at its PCA initialization (gradient gate
+        closed); phase 2 opens the gate and continues at a low learning rate.
+        Both phases share one compiled training function -- only the gate
+        variable, the optimizer state, and the learning rate are reassigned, so
+        phase 2 does not retrace or recompile. Otherwise a single fit runs.
+        Keras resets stateful callbacks (EarlyStopping, ReduceLROnPlateau) at
+        the start of each fit, so the same callback list is reused.
 
         Args:
             model: Compiled Keras model to train.
@@ -1042,12 +1043,12 @@ class TrainingMixin:
         if pca_components is None or not self.config.get("pca_finetune", True):
             return history
 
-        # Phase 2: unfreeze the PCA projection and fine-tune at a low LR.
-        model.get_layer(PCA_LAYER_NAME).trainable = True
-        model.compile(
-            optimizer=self._make_finetune_optimizer(),
-            loss=getattr(self, "_loss_fn", None) or euclidean_distance_loss,
-        )
+        # Phase 2: open the gradient gate so the projection fine-tunes, on a
+        # fresh optimizer state at a low learning rate. The graph is unchanged,
+        # so the compiled training function from phase 1 is reused as-is.
+        model.get_layer(PCA_GATE_NAME).gate.assign(1.0)
+        self._reset_optimizer_state(model.optimizer)
+        model.optimizer.learning_rate = self.config.get("pca_finetune_lr", 1e-4)
         history2 = model.fit(
             train_dataset,
             epochs=max_epochs,
@@ -1057,13 +1058,16 @@ class TrainingMixin:
         )
         return self._concat_histories(history, history2)
 
-    def _make_finetune_optimizer(self):
-        """Build the optimizer for the PCA fine-tuning phase."""
-        return build_optimizer(
-            self.config.get("optimizer_algo", "adam"),
-            self.config.get("pca_finetune_lr", 1e-4),
-            self.config.get("weight_decay", 0.004),
-        )
+    @staticmethod
+    def _reset_optimizer_state(optimizer):
+        """Zero an optimizer's slot variables and step counter in place.
+
+        Gives the fine-tune phase a clean optimizer state without building a
+        new optimizer, which would reset the compile cache and force an XLA
+        recompile. The learning rate is set separately by the caller.
+        """
+        for var in optimizer.variables:
+            var.assign(tf.zeros_like(var))
 
     @staticmethod
     def _concat_histories(history1, history2):

--- a/locator/training.py
+++ b/locator/training.py
@@ -11,6 +11,7 @@ from tensorflow import keras
 
 from .data import (
     IndexSet,
+    build_genotype_table,
     filter_dosage_matrix,
     is_dosage_matrix,
     make_tf_dataset,
@@ -20,6 +21,7 @@ from .data import filter_snps_legacy as filter_snps
 from .gpu_optimizer import GPUOptimizer
 from .models import (
     PCA_LAYER_NAME,
+    IndexedGenotypeModel,
     build_optimizer,
     create_network,
     euclidean_distance_loss,
@@ -350,8 +352,9 @@ class TrainingMixin:
                 self.trainlocs = normalized_locs[train]
                 self.testlocs = normalized_locs[test]
 
-        # Create model if not already created
-        if self.model is None:
+        # Create the model. Rebuild when site_order is given so the bootstrap /
+        # jacknife SNP resampling baked into the model matches this replicate.
+        if self.model is None or site_order is not None:
             # Determine input shape
             if self.traingen is not None:
                 input_shape = self.traingen.shape[1]
@@ -363,14 +366,16 @@ class TrainingMixin:
                 else:
                     input_shape = self.filtered_genotypes.shape[0]
 
-            self.model = self._create_model(input_shape=input_shape)
+            self.model = self._create_model(
+                input_shape=input_shape, site_order=site_order
+            )
 
         # Return early if setup_only
         if setup_only:
             return None
 
         callbacks = self._create_callbacks(boot=boot)
-        self._build_datasets_and_fit(normalized_locs, callbacks, site_order=site_order)
+        self._build_datasets_and_fit(normalized_locs, callbacks)
         self._save_training_artifacts(boot=boot)
         return self.history
 
@@ -582,8 +587,20 @@ class TrainingMixin:
             warnings.warn(f"Failed to save model metadata: {e}")
             # Don't fail training if metadata save fails
 
-    def _create_model(self, input_shape):
-        """Create neural network model. Extracted to avoid duplication."""
+    def _create_model(self, input_shape, site_order=None):
+        """Create the training model.
+
+        Builds the coordinate-prediction network (``inner``) and, when a
+        GPU-resident genotype table is available, wraps it in an
+        IndexedGenotypeModel so genotypes are gathered on-device by sample
+        index. When no genotype matrix is loaded (e.g. building an architecture
+        to load saved weights into) the plain network is returned.
+
+        Args:
+            input_shape: Number of input features the inner network expects.
+            site_order: Optional SNP resampling order for bootstrap/jacknife,
+                applied per batch inside the wrapper.
+        """
         loss_fn = None
         if self.config.get("use_range_penalty"):
             if self.config.get("species_range_shapefile") is None:
@@ -614,7 +631,7 @@ class TrainingMixin:
         self._loss_fn = loss_fn
 
         pca_components = self.config.get("pca_components")
-        model = create_network(
+        inner = create_network(
             input_shape=input_shape,
             width=self.config.get("width", 256),
             n_layers=self.config.get("nlayers", 8),
@@ -628,10 +645,51 @@ class TrainingMixin:
             loss_fn=loss_fn,
         )
 
+        # Without a resident genotype matrix there is nothing to gather from;
+        # return the plain network (used by weight-loading paths).
+        if getattr(self, "filtered_genotypes", None) is None:
+            if pca_components is not None:
+                self._inject_pca_weights(inner, pca_components)
+            return inner
+
+        model = IndexedGenotypeModel(
+            inner,
+            self._get_genotype_table(),
+            site_order=site_order,
+            augment=self.config.get("augmentation"),
+        )
+        model.compile(
+            optimizer=build_optimizer(
+                self.config.get("optimizer_algo", "adam"),
+                self.config.get("learning_rate", 0.001),
+                self.config.get("weight_decay", 0.004),
+            ),
+            loss=loss_fn if loss_fn is not None else euclidean_distance_loss,
+        )
+
         if pca_components is not None:
             self._inject_pca_weights(model, pca_components)
 
         return model
+
+    def _get_genotype_table(self):
+        """Build or reuse the GPU-resident genotype table.
+
+        The table is rebuilt only when ``filtered_genotypes`` is a different
+        array object. A Ray actor reuses one Locator and one shared
+        ``filtered_genotypes`` across all its folds, so the table is built once
+        per actor; windowed analysis filters a fresh array per window, so the
+        identity check correctly triggers a rebuild there. ``_filter_genotypes``
+        assigns ``filtered_genotypes`` by reference (never a copy), which keeps
+        this identity guard exact.
+        """
+        if (
+            self._genotype_table is None
+            or self.filtered_genotypes is not self._genotype_table_src
+        ):
+            self._genotype_table = build_genotype_table(self.filtered_genotypes)
+            self._genotype_table_src = self.filtered_genotypes
+        return self._genotype_table
 
     def _inject_pca_weights(self, model, pca_components):
         """Initialize the pca_projection layer with PCA loadings and freeze it.
@@ -786,8 +844,10 @@ class TrainingMixin:
             "disable_gpu", False
         ):
             try:
+                # Probe the inner network: it consumes genotype features, while
+                # the IndexedGenotypeModel wrapper consumes sample indices.
                 optimal_batch = GPUOptimizer.get_optimal_batch_size(
-                    self.model,
+                    getattr(self.model, "inner", self.model),
                     input_shape=(self.filtered_genotypes.shape[0],),
                     target_memory_usage=0.85,
                     dataset_size=dataset_size,
@@ -892,18 +952,17 @@ class TrainingMixin:
         self,
         normalized_locs,
         callbacks,
-        site_order=None,
         keras_verbose=None,
     ):
         """Build tf.data pipelines and train the model.
 
         Requires self.filtered_genotypes, self.index_set, self.model,
-        and self.sample_weights to be set before calling.
+        and self.sample_weights to be set before calling. SNP resampling
+        (site_order) is handled inside the model, not the dataset.
 
         Args:
             normalized_locs: Full normalized location array
             callbacks: List of Keras callbacks
-            site_order: Optional SNP reordering for bootstrap
             keras_verbose: Verbosity for model.fit (default: from config)
 
         Returns
@@ -916,7 +975,6 @@ class TrainingMixin:
             keras_verbose = self.config.get("keras_verbose", 1)
 
         train_dataset = make_tf_dataset(
-            genotypes=self.filtered_genotypes,
             coordinates=normalized_locs,
             index_set=self.index_set,
             split="train",
@@ -925,19 +983,14 @@ class TrainingMixin:
                 self.sample_weights["sample_weights"] if self.sample_weights else None
             ),
             training=True,
-            cache=True,
-            site_order=site_order,
         )
 
         val_dataset = make_tf_dataset(
-            genotypes=self.filtered_genotypes,
             coordinates=normalized_locs,
             index_set=self.index_set,
             split="test",
             batch_size=batch_size,
             training=False,
-            cache=True,
-            site_order=site_order,
         )
 
         self.history = self._fit_model(

--- a/locator/training.py
+++ b/locator/training.py
@@ -477,8 +477,18 @@ class TrainingMixin:
         # Handle sample weights if enabled
         self._calculate_sample_weights(train_indices)
 
-        # Create model
-        self.model = self._create_model(input_shape=self.filtered_genotypes.shape[0])
+        # Build the model, or reuse the previous fold's. Reuse is valid only
+        # when the genotype table is unchanged (k-fold/LOO sharing one filtered
+        # array, as a Ray actor does); it keeps the compiled training function,
+        # avoiding a per-fold XLA recompile.
+        current_table = self._get_genotype_table()
+        if (
+            isinstance(self.model, IndexedGenotypeModel)
+            and self.model.genotype_table is current_table
+        ):
+            self._reset_model_for_fold()
+        else:
+            self.model = self._create_model(input_shape=self.filtered_genotypes.shape[0])
 
         # Create callbacks
         # For train_holdout, we might want to skip saving intermediate models
@@ -1060,14 +1070,67 @@ class TrainingMixin:
 
     @staticmethod
     def _reset_optimizer_state(optimizer):
-        """Zero an optimizer's slot variables and step counter in place.
+        """Zero an optimizer's momentum/velocity slots and step counter.
 
-        Gives the fine-tune phase a clean optimizer state without building a
-        new optimizer, which would reset the compile cache and force an XLA
-        recompile. The learning rate is set separately by the caller.
+        Gives a reused model -- the fine-tune phase, or the next fold -- a
+        clean optimizer state without building a new optimizer, which would
+        reset the compile cache and force an XLA recompile. Under mixed
+        precision the optimizer is a LossScaleOptimizer wrapping the real one;
+        only the inner optimizer is zeroed, so the adapting loss scale is left
+        intact (zeroing it would stall training). The learning rate is zeroed
+        here too and must be set by the caller afterwards.
         """
-        for var in optimizer.variables:
+        inner = getattr(optimizer, "inner_optimizer", optimizer)
+        for var in inner.variables:
             var.assign(tf.zeros_like(var))
+
+    @staticmethod
+    def _reinitialize_layer_weights(model):
+        """Re-draw every layer weight from its initializer.
+
+        Used when reusing a model across folds: gives each fold a fresh random
+        initialization, exactly as a newly constructed network would have,
+        while keeping the compiled training function. Covers the weight kinds
+        create_network produces (Dense kernel/bias, BatchNormalization
+        gamma/beta and moving statistics); raises if a trainable weight is
+        left uncovered so a future architecture change cannot silently leak
+        state between folds.
+        """
+        reset = set()
+        for layer in model.layers:
+            for weight_attr, init_attr in (
+                ("kernel", "kernel_initializer"),
+                ("bias", "bias_initializer"),
+                ("gamma", "gamma_initializer"),
+                ("beta", "beta_initializer"),
+                ("moving_mean", "moving_mean_initializer"),
+                ("moving_variance", "moving_variance_initializer"),
+            ):
+                weight = getattr(layer, weight_attr, None)
+                initializer = getattr(layer, init_attr, None)
+                if weight is not None and initializer is not None:
+                    weight.assign(initializer(weight.shape, weight.dtype))
+                    reset.add(id(weight))
+        missed = [w for w in model.trainable_variables if id(w) not in reset]
+        if missed:
+            raise RuntimeError(
+                "_reinitialize_layer_weights left weights uncovered: "
+                f"{[w.name for w in missed]}"
+            )
+
+    def _reset_model_for_fold(self):
+        """Reset a reused model to a fresh per-fold starting state.
+
+        Re-draws all layer weights from their initializers, zeros the
+        optimizer state, restores the base learning rate, and re-fits the
+        per-fold PCA projection. The compiled training function is left
+        intact, so the fold does not pay an XLA recompile.
+        """
+        self._reinitialize_layer_weights(self.model.inner)
+        self._reset_optimizer_state(self.model.optimizer)
+        self.model.optimizer.learning_rate = self.config.get("learning_rate", 0.001)
+        if self.config.get("pca_components") is not None:
+            self._inject_pca_weights(self.model, self.config["pca_components"])
 
     @staticmethod
     def _concat_histories(history1, history2):

--- a/scripts/benchmark_dataloader.py
+++ b/scripts/benchmark_dataloader.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python
+"""Benchmark the genotype data loader through repeated holdout training.
+
+Drives the public ``Locator.train_holdout`` API on a synthetic genotype matrix
+so it runs unchanged against both the old and new loader. To compare before and
+after the GPU-resident loader refactor, run it once with the ``locator/`` changes
+stashed and once with them applied:
+
+    git stash
+    pixi run python scripts/benchmark_dataloader.py
+    git stash pop
+    pixi run python scripts/benchmark_dataloader.py
+
+The synthetic matrix is fixed-shape and seeded, so timings are comparable. One
+Locator instance is reused across folds, mirroring how a Ray actor reuses a
+worker; with the new loader the genotype table is then built once and reused,
+so fold 0 pays the build and later folds do not.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import time
+
+import numpy as np
+import pandas as pd
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--n-snps", type=int, default=1_000_000)
+    p.add_argument("--n-samples", type=int, default=236)
+    p.add_argument("--epochs", type=int, default=30, help="fixed epochs per fold")
+    p.add_argument("--folds", type=int, default=3)
+    p.add_argument("--batch-size", type=int, default=32)
+    p.add_argument("--width", type=int, default=256)
+    p.add_argument("--n-layers", type=int, default=8)
+    p.add_argument("--holdout", type=int, default=10, help="samples held out per fold")
+    p.add_argument(
+        "--pca-components",
+        type=int,
+        default=None,
+        help="enable PCA-init projection (the realistic n_SNPs >> n_samples "
+        "regime); keeps the trainable model small so the data path is visible",
+    )
+    p.add_argument("--seed", type=int, default=1234)
+    return p.parse_args()
+
+
+def gpu_snapshot():
+    """Return a one-line nvidia-smi utilisation/memory snapshot, or a note."""
+    try:
+        out = subprocess.run(
+            [
+                "nvidia-smi",
+                "--query-gpu=index,utilization.gpu,memory.used,memory.total",
+                "--format=csv,noheader",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        return out.stdout.strip() or "(no GPU reported)"
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return "(nvidia-smi unavailable)"
+
+
+def make_synthetic_data(n_snps, n_samples, seed):
+    """Build a pre-filtered int8 genotype matrix and matching sample metadata."""
+    rng = np.random.default_rng(seed)
+    # (n_snps, n_samples) is locator's filtered-genotype layout.
+    filtered = rng.integers(0, 3, size=(n_snps, n_samples), dtype=np.int8)
+    samples = np.array([f"s{i}" for i in range(n_samples)])
+    sample_df = pd.DataFrame(
+        {
+            "sampleID": samples,
+            "x": rng.uniform(-120, -115, size=n_samples),
+            "y": rng.uniform(35, 45, size=n_samples),
+        }
+    )
+    return filtered, samples, sample_df
+
+
+def main():
+    args = parse_args()
+
+    from locator.core import Locator
+
+    print("GPU before run :", gpu_snapshot())
+    print(
+        f"Synthetic data : {args.n_snps:,} SNPs x {args.n_samples} samples "
+        f"(int8, {args.n_snps * args.n_samples / 1e6:.0f} MB resident)"
+    )
+
+    t0 = time.perf_counter()
+    filtered, samples, sample_df = make_synthetic_data(
+        args.n_snps, args.n_samples, args.seed
+    )
+    print(f"Data generation: {time.perf_counter() - t0:.1f} s\n")
+
+    config = {
+        "out": "/tmp/locator_benchmark",
+        "sample_data": sample_df,
+        "max_epochs": args.epochs,
+        "patience": args.epochs + 1000,  # disable early stopping
+        "batch_size": args.batch_size,
+        "width": args.width,
+        "nlayers": args.n_layers,
+        "keras_verbose": 0,
+        "holdout_no_intermediate_saves": True,
+        "save_fold_models": False,
+    }
+    if args.pca_components:
+        config["pca_components"] = args.pca_components
+        # Keep the projection frozen so per-epoch time reflects the data path
+        # rather than a second fine-tuning phase.
+        config["pca_finetune"] = False
+
+    # One Locator reused across folds, as a Ray worker would be.
+    loc = Locator(config)
+    rng = np.random.default_rng(args.seed)
+
+    fold_times = []
+    for fold in range(args.folds):
+        holdout_idx = rng.choice(args.n_samples, args.holdout, replace=False)
+        t_fold = time.perf_counter()
+        loc.train_holdout(
+            genotypes=None,
+            samples=samples,
+            holdout_indices=list(holdout_idx),
+            filtered_genotypes=filtered,
+        )
+        elapsed = time.perf_counter() - t_fold
+        fold_times.append(elapsed)
+        print(
+            f"fold {fold}: {elapsed:7.2f} s total  "
+            f"{elapsed / args.epochs * 1000:7.1f} ms/epoch"
+        )
+
+    print()
+    print("GPU during/after:", gpu_snapshot())
+    print()
+    steady = fold_times[1:] or fold_times
+    print(f"fold 0 (incl. table build): {fold_times[0]:.2f} s")
+    print(f"steady-state fold mean    : {np.mean(steady):.2f} s")
+    print(f"steady-state ms/epoch     : {np.mean(steady) / args.epochs * 1000:.1f} ms")
+    print(
+        f"build-once saving (fold0 - steady mean): "
+        f"{fold_times[0] - np.mean(steady):+.2f} s"
+    )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_analysis_tf_data.py
+++ b/tests/test_analysis_tf_data.py
@@ -193,11 +193,12 @@ class TestAnalysisTFData:
         # Should have been called at least twice (train and validation datasets)
         assert call_count >= 2
 
-        # Verify the calls included correct parameters
+        # Verify the calls included correct parameters. The index-based
+        # pipeline carries coordinates and indices, not the genotype matrix.
         calls = mock_make_tf_dataset.call_args_list
         for call in calls:
             kwargs = call[1]
-            assert "genotypes" in kwargs
+            assert "coordinates" in kwargs
             assert "index_set" in kwargs
             assert "split" in kwargs
 

--- a/tests/test_pca_init.py
+++ b/tests/test_pca_init.py
@@ -6,7 +6,7 @@ from sklearn.decomposition import PCA
 
 from locator import Locator
 from locator.models import PCA_LAYER_NAME
-from locator.pca import compute_pca_projection
+from locator.pca import compute_pca_projection, compute_pca_projection_gram
 
 
 def _pca_config(basic_config, **overrides):
@@ -62,7 +62,8 @@ def test_frozen_projection_keeps_pca_loadings(genotype_data, basic_config):
     train_geno = np.asarray(
         loc.filtered_genotypes[:, loc.index_set.train].T, dtype=np.float32
     )
-    expected, _ = compute_pca_projection(train_geno, 8)
+    # Training fits PCA via the Gram-matrix path, so compare against that.
+    expected, _ = compute_pca_projection_gram(train_geno, 8)
     assert np.allclose(kernel, expected, atol=1e-5)
 
 
@@ -78,7 +79,7 @@ def test_finetune_moves_projection(genotype_data, basic_config):
     train_geno = np.asarray(
         loc.filtered_genotypes[:, loc.index_set.train].T, dtype=np.float32
     )
-    pca_loadings, _ = compute_pca_projection(train_geno, 8)
+    pca_loadings, _ = compute_pca_projection_gram(train_geno, 8)
     assert not np.allclose(kernel, pca_loadings, atol=1e-6)
 
 

--- a/tests/test_pca_init.py
+++ b/tests/test_pca_init.py
@@ -126,3 +126,28 @@ def test_pca_components_rejects_site_order(genotype_data, basic_config):
     loc = Locator(_pca_config(basic_config, pca_components=8, max_epochs=1))
     with pytest.raises(ValueError, match="bootstrap"):
         loc.train(genotypes=genotypes, samples=samples, site_order=np.arange(n_snps))
+
+
+def test_gradient_gate_controls_gradient_flow():
+    """GradientGate passes values through but gates the gradient to its input.
+
+    Defined last: it runs TensorFlow ops, and the Locator-based tests above
+    must configure TF threading before the eager context is initialized.
+    """
+    import tensorflow as tf
+
+    from locator.models import GradientGate
+
+    gate = GradientGate(dtype="float32")
+    x = tf.Variable([[1.0, -2.0, 3.0]])
+    gate(x)  # first call builds the gate weight
+
+    for g, expected_grad in [(0.0, 0.0), (1.0, 1.0)]:
+        gate.gate.assign(g)
+        with tf.GradientTape() as tape:
+            y = gate(x)
+        grad = tape.gradient(y, x)
+        # Output value equals the input regardless of the gate state.
+        assert np.allclose(y.numpy(), x.numpy())
+        # Gradient reaching the input is scaled by the gate.
+        assert np.allclose(grad.numpy(), expected_grad)

--- a/tests/test_predict_tf_data.py
+++ b/tests/test_predict_tf_data.py
@@ -1,7 +1,5 @@
 """Test predict() method with tf.data pipeline"""
 
-from unittest.mock import Mock, patch
-
 import numpy as np
 import pandas as pd
 import pytest
@@ -102,33 +100,29 @@ class TestPredictTFData:
         # Should still work
         assert isinstance(predictions, pd.DataFrame)
 
-    @patch("locator.data.make_tf_dataset")
-    def test_predict_uses_make_tf_dataset(
-        self, mock_make_tf_dataset, genotype_data, basic_config
+    def test_predict_runs_inner_network_on_feature_array(
+        self, genotype_data, basic_config
     ):
-        """Test that predict() calls make_tf_dataset for tf.data pipeline"""
+        """predict() runs the inner network on a sample-major feature array."""
         genotypes, samples, _, _, _ = genotype_data
 
-        # Set up mock to return a mock dataset
-        mock_dataset = Mock()
-        mock_make_tf_dataset.return_value = mock_dataset
-
-        # Create locator and train
         locator = Locator(basic_config)
         locator.train(genotypes=genotypes, samples=samples)
 
-        # Mock model predict to avoid actual prediction
-        locator.model.predict = Mock(return_value=np.random.randn(5, 2))
+        # predict() unwraps IndexedGenotypeModel and feeds genotype features
+        # (shape (n_predict, n_snps)) straight to the inner network.
+        n_snps = locator.filtered_genotypes.shape[0]
+        captured = {}
+        inner = locator.model.inner
 
-        # Call predict with new approach
+        def spy(x, *args, **kwargs):
+            arr = np.asarray(x)
+            captured["x"] = arr
+            return np.random.randn(arr.shape[0], 2)
+
+        inner.predict = spy
         locator.predict(genotypes=genotypes, samples=samples, return_df=True)
 
-        # Verify make_tf_dataset was called
-        assert mock_make_tf_dataset.called
-        call_kwargs = mock_make_tf_dataset.call_args[1]
-
-        # Check parameters
-        assert "genotypes" in call_kwargs
-        assert "index_set" in call_kwargs
-        assert call_kwargs["split"] == "predict"
-        assert call_kwargs["training"] is False
+        assert "x" in captured
+        assert captured["x"].ndim == 2
+        assert captured["x"].shape[1] == n_snps

--- a/tests/test_tf_data_integration.py
+++ b/tests/test_tf_data_integration.py
@@ -35,3 +35,24 @@ class TestTFDataIntegration:
         # First argument should be a tf.data.Dataset
         train_data = fit_call[0][0]
         assert hasattr(train_data, "__iter__")  # It's a dataset, not a numpy array
+
+    def test_train_holdout_reuses_model_across_folds(self, genotype_data, basic_config):
+        """Folds sharing one genotype table reuse the compiled model."""
+        from locator.models import IndexedGenotypeModel
+
+        genotypes, samples, _, _, _ = genotype_data
+        locator = Locator(basic_config)
+        # One shared filtered array, as the parallel k-fold/LOO dispatch does.
+        filtered = locator._filter_genotypes(genotypes)
+
+        locator.train_holdout(
+            samples=samples, holdout_indices=[0, 1, 2], filtered_genotypes=filtered
+        )
+        first_model = locator.model
+        assert isinstance(first_model, IndexedGenotypeModel)
+
+        locator.train_holdout(
+            samples=samples, holdout_indices=[3, 4, 5], filtered_genotypes=filtered
+        )
+        # The second fold reused the same compiled model object.
+        assert locator.model is first_model

--- a/tests/test_tf_dataset.py
+++ b/tests/test_tf_dataset.py
@@ -1,4 +1,4 @@
-"""Tests for unified TensorFlow dataset creation."""
+"""Tests for index-based TensorFlow dataset creation and the genotype table."""
 
 import numpy as np
 import pytest
@@ -6,23 +6,21 @@ import tensorflow as tf
 
 from locator.data import (
     IndexSet,
+    build_genotype_table,
     flip_genotypes_tf,
     make_tf_dataset,
     make_tf_dataset_from_arrays,
 )
+from locator.models import IndexedGenotypeModel, create_network
 
 
 class TestMakeTFDataset:
-    """Test the main make_tf_dataset function."""
+    """Test the index-based make_tf_dataset function."""
 
     def setup_method(self):
         """Create test data."""
         np.random.seed(42)
-        self.n_snps = 100
         self.n_samples = 50
-        self.genotypes = np.random.randint(
-            0, 3, size=(self.n_snps, self.n_samples)
-        ).astype(np.float32)
         self.coordinates = np.random.randn(self.n_samples, 2).astype(np.float32)
 
         # Create IndexSet with train/val/test splits
@@ -31,110 +29,70 @@ class TestMakeTFDataset:
         )
 
     def test_basic_dataset_creation(self):
-        """Test basic dataset creation without weights or augmentation."""
+        """Dataset yields (sample_index, coordinate) batches."""
         dataset = make_tf_dataset(
-            genotypes=self.genotypes,
             coordinates=self.coordinates,
             index_set=self.index_set,
             split="train",
             batch_size=10,
             training=True,
-            cache=False,  # Disable caching for testing
             prefetch=False,
         )
 
-        # Check that we can iterate through the dataset
-        for batch_count, batch in enumerate(dataset):
-            features, labels = batch
+        batch_count = -1
+        for batch_count, (idx, coord) in enumerate(dataset):
+            assert idx.shape == (10,)
+            assert coord.shape == (10, 2)
+            assert idx.dtype == tf.int32
+            assert coord.dtype == tf.float32
+            # Coordinates must stay aligned to their sample index.
+            np.testing.assert_array_equal(coord.numpy(), self.coordinates[idx.numpy()])
 
-            # Check shapes
-            assert features.shape == (10, self.n_snps)  # (batch_size, n_features)
-            assert labels.shape == (10, 2)  # (batch_size, 2)
-
-            # Check dtypes
-            assert features.dtype == tf.float32
-            assert labels.dtype == tf.float32
-
-        # We should have 3 batches (30 samples / 10 batch_size)
-        assert batch_count == 2  # enumerate counts from 0, so 3 batches = 0, 1, 2
+        # 30 training samples / batch 10, drop_remainder defaults to training.
+        assert batch_count == 2
 
     def test_dataset_with_sample_weights(self):
-        """Test dataset creation with sample weights."""
-        # Create sample weights
+        """Dataset yields (index, coordinate, weight) when weights are given."""
         train_size = len(self.index_set.train)
         sample_weights = np.random.rand(train_size).astype(np.float32)
 
         dataset = make_tf_dataset(
-            genotypes=self.genotypes,
             coordinates=self.coordinates,
             index_set=self.index_set,
             split="train",
             batch_size=10,
             sample_weights=sample_weights,
             training=True,
-            cache=False,
             prefetch=False,
         )
 
-        # Check that dataset returns 3 elements
         for batch in dataset.take(1):
             assert len(batch) == 3
-            features, labels, weights = batch
-
-            assert features.shape == (10, self.n_snps)
-            assert labels.shape == (10, 2)
+            idx, coord, weights = batch
+            assert idx.shape == (10,)
+            assert coord.shape == (10, 2)
             assert weights.shape == (10,)
             assert weights.dtype == tf.float32
 
-    def test_dataset_with_augmentation(self):
-        """Test dataset with augmentation enabled."""
-        augment_config = {"enabled": True, "flip_rate": 0.1}
-
+    def test_validation_split_keeps_partial_batch(self):
+        """Non-training splits keep the final partial batch."""
         dataset = make_tf_dataset(
-            genotypes=self.genotypes,
             coordinates=self.coordinates,
             index_set=self.index_set,
-            split="train",
-            batch_size=10,
-            augment=augment_config,
-            training=True,
-            cache=False,
-            prefetch=False,
-        )
-
-        # Just verify we can iterate - augmentation is stochastic
-        for batch in dataset.take(1):
-            features, labels = batch
-            assert features.shape == (10, self.n_snps)
-            assert labels.shape == (10, 2)
-
-    def test_dataset_with_site_order(self):
-        """Test bootstrap resampling with site_order."""
-        # Create random site order for bootstrap
-        site_order = np.random.choice(self.n_snps, self.n_snps, replace=True)
-
-        dataset = make_tf_dataset(
-            genotypes=self.genotypes,
-            coordinates=self.coordinates,
-            index_set=self.index_set,
-            split="train",
-            batch_size=10,
-            site_order=site_order,
+            split="val",
+            batch_size=4,
             training=False,
-            cache=False,
             prefetch=False,
         )
 
-        # Verify shapes are correct
-        for batch in dataset.take(1):
-            features, labels = batch
-            assert features.shape[1] == self.n_snps  # Same number of SNPs
+        n_val = len(self.index_set.get_split("val"))
+        total = sum(int(idx.shape[0]) for idx, _ in dataset)
+        assert total == n_val
 
     def test_invalid_split_raises_error(self):
-        """Test that invalid split name raises error."""
+        """An unknown split name raises KeyError."""
         with pytest.raises(KeyError):
             make_tf_dataset(
-                genotypes=self.genotypes,
                 coordinates=self.coordinates,
                 index_set=self.index_set,
                 split="nonexistent",
@@ -142,12 +100,11 @@ class TestMakeTFDataset:
             )
 
     def test_mismatched_weights_raises_error(self):
-        """Test that mismatched weight length raises error."""
-        wrong_weights = np.random.rand(100)  # Wrong size
+        """A weight array that does not match the split size raises ValueError."""
+        wrong_weights = np.random.rand(100)
 
         with pytest.raises(ValueError, match="Sample weights length"):
             make_tf_dataset(
-                genotypes=self.genotypes,
                 coordinates=self.coordinates,
                 index_set=self.index_set,
                 split="train",
@@ -155,24 +112,85 @@ class TestMakeTFDataset:
                 sample_weights=wrong_weights,
             )
 
-    def test_mixed_precision_dtype(self):
-        """Test dataset creation with float16 dtype."""
-        dataset = make_tf_dataset(
-            genotypes=self.genotypes,
-            coordinates=self.coordinates,
-            index_set=self.index_set,
-            split="train",
-            batch_size=10,
-            dtype_policy="float16",
-            training=False,
-            cache=False,
-            prefetch=False,
-        )
 
-        for batch in dataset.take(1):
-            features, labels = batch
-            assert features.dtype == tf.float16
-            assert labels.dtype == tf.float32  # Coords always float32
+class TestBuildGenotypeTable:
+    """Test the GPU-resident genotype table builder."""
+
+    def test_sample_major_layout(self):
+        """The table is the sample-major transpose of the input."""
+        geno = np.random.randint(0, 3, size=(60, 15)).astype(np.int8)
+        table = build_genotype_table(geno)
+
+        assert table.shape == (15, 60)  # (n_samples, n_snps)
+        np.testing.assert_array_equal(table.numpy(), geno.T)
+
+    def test_preserves_int8_dtype(self):
+        """int8 hard-call inputs stay int8."""
+        geno = np.random.randint(0, 3, size=(30, 8)).astype(np.int8)
+        assert build_genotype_table(geno).dtype == tf.int8
+
+    def test_preserves_float32_dtype(self):
+        """float32 dosage inputs stay float32."""
+        geno = np.random.rand(30, 8).astype(np.float32) * 2.0
+        assert build_genotype_table(geno).dtype == tf.float32
+
+
+class TestIndexedGenotypeModel:
+    """Test the on-device gather wrapper model."""
+
+    def test_batched_gather_matches_manual_gather(self):
+        """wrapper(idx) equals inner(gather(table, idx)) for the same network."""
+        np.random.seed(0)
+        n_snps, n_samples = 40, 20
+        geno = np.random.randint(0, 3, size=(n_snps, n_samples)).astype(np.int8)
+
+        inner = create_network(input_shape=n_snps, width=8, n_layers=2)
+        table = build_genotype_table(geno)
+        wrapper = IndexedGenotypeModel(inner, table)
+
+        idx = tf.constant([5, 0, 12, 19, 3], dtype=tf.int32)
+        out_wrapper = wrapper(idx, training=False).numpy()
+
+        manual_features = tf.cast(tf.gather(geno.T, idx), tf.float32)
+        out_manual = inner(manual_features, training=False).numpy()
+
+        np.testing.assert_allclose(out_wrapper, out_manual, rtol=1e-5, atol=1e-5)
+
+    def test_site_order_column_gather(self):
+        """site_order resamples SNP columns after the per-sample row gather."""
+        np.random.seed(1)
+        n_snps, n_samples = 40, 20
+        geno = np.random.randint(0, 3, size=(n_snps, n_samples)).astype(np.int8)
+        site_order = np.random.choice(n_snps, n_snps, replace=True)
+
+        inner = create_network(input_shape=n_snps, width=8, n_layers=2)
+        table = build_genotype_table(geno)
+        wrapper = IndexedGenotypeModel(inner, table, site_order=site_order)
+
+        idx = tf.constant([2, 7, 11], dtype=tf.int32)
+        out_wrapper = wrapper(idx, training=False).numpy()
+
+        g = tf.gather(geno.T, idx)
+        g = tf.gather(g, site_order, axis=1)
+        out_manual = inner(tf.cast(g, tf.float32), training=False).numpy()
+
+        np.testing.assert_allclose(out_wrapper, out_manual, rtol=1e-5, atol=1e-5)
+
+    def test_save_weights_delegates_to_inner(self, tmp_path):
+        """Weights round-trip through inner so the on-disk format is unchanged."""
+        n_snps = 30
+        inner = create_network(input_shape=n_snps, width=8, n_layers=2)
+        geno = np.random.randint(0, 3, size=(n_snps, 10)).astype(np.int8)
+        wrapper = IndexedGenotypeModel(inner, build_genotype_table(geno))
+
+        path = str(tmp_path / "model.weights.h5")
+        wrapper.save_weights(path)
+
+        # A bare network of the same architecture can load the file.
+        reloaded = create_network(input_shape=n_snps, width=8, n_layers=2)
+        reloaded.load_weights(path)
+        for w_a, w_b in zip(inner.get_weights(), reloaded.get_weights(), strict=True):
+            np.testing.assert_array_equal(w_a, w_b)
 
 
 class TestFlipGenotypesTF:
@@ -180,36 +198,29 @@ class TestFlipGenotypesTF:
 
     def test_flip_genotypes_basic(self):
         """Test basic genotype flipping."""
-        # Create test genotypes with known values
         genotypes = tf.constant([0.0, 1.0, 0.0, 1.0, 2.0], dtype=tf.float32)
-
-        # Set seed for reproducibility
         tf.random.set_seed(42)
 
-        # Apply flipping with high rate to ensure some flips
         flipped = flip_genotypes_tf(genotypes, flip_rate=0.8)
 
-        # Check that 2s (missing) are never flipped
+        # 2s (missing) are never flipped
         original_2s = tf.where(genotypes == 2.0)
         flipped_2s = tf.gather(flipped, original_2s)
         assert tf.reduce_all(flipped_2s == 2.0)
 
-        # Check shape is preserved
         assert flipped.shape == genotypes.shape
 
     def test_flip_preserves_missing_values(self):
-        """Test that missing values (2) are never flipped."""
+        """Missing values (2) are never flipped."""
         genotypes = tf.constant([[0.0, 1.0, 2.0], [2.0, 0.0, 1.0]], dtype=tf.float32)
 
-        # Apply flipping many times
         for _ in range(10):
             flipped = flip_genotypes_tf(genotypes, flip_rate=0.5)
-            # Check all 2s remain 2s
             assert tf.reduce_all(tf.where(genotypes == 2.0, flipped == 2.0, True))
 
 
 class TestMakeTFDatasetFromArrays:
-    """Test the legacy compatibility function."""
+    """Test the legacy feature-based compatibility function."""
 
     def test_single_dataset_creation(self):
         """Test creating a single training dataset."""
@@ -224,10 +235,8 @@ class TestMakeTFDatasetFromArrays:
             prefetch=False,
         )
 
-        # Should return single dataset
         assert isinstance(dataset, tf.data.Dataset)
 
-        # Check shapes
         for batch in dataset.take(1):
             features, labels = batch
             assert features.shape == (10, 100)
@@ -254,18 +263,10 @@ class TestMakeTFDatasetFromArrays:
             prefetch=False,
         )
 
-        # Check all three datasets
         for ds in [train_ds, test_ds, val_ds]:
             assert isinstance(ds, tf.data.Dataset)
 
-        # Verify different behaviors
-        # Training should have drop_remainder=True by default
-        train_batch_count = sum(1 for _ in train_ds)
-        assert train_batch_count == 6  # 30 / 5
-
-        # Test/val should have drop_remainder=False by default
-        test_batch_count = sum(1 for _ in test_ds)
-        assert test_batch_count == 2  # 10 / 5
-
-        val_batch_count = sum(1 for _ in val_ds)
-        assert val_batch_count == 2  # 10 / 5
+        # Training drops the partial final batch; validation/test keep it.
+        assert sum(1 for _ in train_ds) == 6  # 30 / 5
+        assert sum(1 for _ in test_ds) == 2  # 10 / 5
+        assert sum(1 for _ in val_ds) == 2  # 10 / 5


### PR DESCRIPTION
## Summary

Reworks locator's disk-to-GPU genotype data path and the per-fold setup
costs that dominate k-fold and leave-one-out runs.

The genotype matrix for realistic runs is sub-GB and now lives on the GPU
for the whole run: an `IndexedGenotypeModel` wraps the coordinate-prediction
network, takes sample indices as input, and gathers genotype rows from a
build-once, sample-major, native-dtype resident table. `make_tf_dataset` is
reduced to an index-only pipeline carrying just indices and coordinates.

Profiling that loader showed data movement was never the wall-clock
bottleneck -- per-fold setup was. Three follow-on changes cut it:

- **On-GPU PCA.** The PCA-init projection is fit via a Gram-matrix
  eigendecomposition on the resident table instead of sklearn on a host
  matrix: ~25 s to ~1 s per fold, and exact rather than a randomized SVD.
- **Fine-tune redesign.** A `GradientGate` layer keeps the projection
  permanently trainable; phase 1 vs phase 2 is a variable flip plus a
  learning-rate change, not a freeze/unfreeze and recompile. Removes the
  phase-2 XLA recompile.
- **Model reuse.** k-fold/LOO folds sharing one genotype table reuse the
  compiled model -- fresh weights, reset optimizer, re-fit PCA -- instead of
  rebuilding and recompiling. Removes the per-fold XLA recompile.

## Measured impact (1M SNPs x 236 samples, PCA-128, A100)

| | before | after |
|---|--:|--:|
| per-fold PCA fit | ~25 s | ~1 s |
| phase-2 first epoch | ~5-7 s | ~1.3 s |
| reused fold first epoch | ~5-8 s | ~2 s |
| warm train_holdout fold | tens of s | ~10 s |

A 225-fold LOO run drops from roughly two hours of setup to well under an
hour. GPU memory is roughly halved in the PCA regime (one int8 resident
table replaces re-materialised fp16/fp32 copies).

## Notes

- Checkpoint format is unchanged: `IndexedGenotypeModel` delegates
  `save_weights`/`load_weights` to the inner network.
- Prediction stays feature-array based (a single forward pass, not a
  bottleneck); the resident table and index pipeline are training-only.
- `scripts/benchmark_dataloader.py` is a synthetic before/after timing
  harness for the data path.

## Testing

Full test suite passes (274 passed, 1 skipped); lint and format clean; a
GPU smoke test confirms the on-device path.