### PR TITLE
feat(gl): expose GL site-filter thresholds as flags and kwargs

### DIFF
--- a/docs/genotype_likelihoods.md
+++ b/docs/genotype_likelihoods.md
@@ -65,17 +65,34 @@ similar dosage values.
 
 ## Site filtering
 
-Hard-coded defaults applied inside the loader:
+Three thresholds control which sites survive. Each has a CLI flag and a
+matching `load_genotypes` keyword; the values below are the defaults.
 
-| Threshold | Value | Effect |
-|---|---|---|
-| `gl_missing_threshold` | 0.4 | Sample at site is missing if `max(GL_AA, GL_AB, GL_BB) < 0.4` (near-uniform GL = no information) |
-| `max_missing_frac` | 0.10 | Site dropped if missing fraction across samples exceeds this |
-| `min_maf` | 0.01 | Site dropped if mean-dosage-derived MAF falls below this |
+| Threshold | CLI flag | Default | Effect |
+|---|---|---|---|
+| `gl_missing_threshold` | `--gl_missing_threshold` | 0.4 | Sample at site is missing if `max(GL_AA, GL_AB, GL_BB) < this` (near-uniform GL = no information) |
+| `gl_max_missing_frac` | `--gl_max_missing_frac` | 0.10 | Site dropped if missing fraction across samples exceeds this |
+| `gl_min_maf` | `--gl_min_maf` | 0.01 | Site dropped if mean-dosage-derived MAF falls below this |
 
-These are not yet surfaced as CLI flags. If your dataset needs different
-thresholds, edit `locator/loaders.py:_load_from_gl` directly or open an
-issue.
+Override them on the command line:
+
+```bash
+locator --gl output.beagle.gz --bam_list bam.filelist \
+    --sample_data data/sample_data.txt --out out/gl_run/run1 \
+    --gl_min_maf 0.05 --gl_max_missing_frac 0.20 --gl_missing_threshold 0.5
+```
+
+Or via the Python API:
+
+```python
+genotypes, samples = loc.load_genotypes(
+    gl="output.beagle.gz",
+    bam_list="bam.filelist",
+    gl_min_maf=0.05,
+    gl_max_missing_frac=0.20,
+    gl_missing_threshold=0.5,
+)
+```
 
 ## Missing data
 

--- a/locator/cli.py
+++ b/locator/cli.py
@@ -63,6 +63,28 @@ def parse_args():
         "--gl is set.",
     )
     parser.add_argument(
+        "--gl_min_maf",
+        type=float,
+        default=0.01,
+        help="GL site filter: drop sites with mean-dosage MAF below this. "
+        "Ignored unless --gl is set. default: 0.01",
+    )
+    parser.add_argument(
+        "--gl_max_missing_frac",
+        type=float,
+        default=0.10,
+        help="GL site filter: drop sites whose fraction of missing samples "
+        "exceeds this. Ignored unless --gl is set. default: 0.10",
+    )
+    parser.add_argument(
+        "--gl_missing_threshold",
+        type=float,
+        default=0.4,
+        help="GL missingness call: a sample at a site is missing if "
+        "max(GL_AA, GL_AB, GL_BB) < this. Ignored unless --gl is set. "
+        "default: 0.40",
+    )
+    parser.add_argument(
         "--sample_data",
         help="tab-delimited text file with columns\
                          'sampleID \t x \t y'.\
@@ -278,6 +300,9 @@ def main():  # noqa: C901
         gl=args.gl,
         bam_list=args.bam_list,
         gl_mode=args.gl_mode,
+        gl_missing_threshold=args.gl_missing_threshold,
+        gl_min_maf=args.gl_min_maf,
+        gl_max_missing_frac=args.gl_max_missing_frac,
     )
     sample_data, locs = loc.sort_samples(samples, args.sample_data)
 

--- a/locator/loaders.py
+++ b/locator/loaders.py
@@ -235,7 +235,15 @@ class DataLoaderMixin:
         samples = np.array(df.index, dtype=object)
         return dosage, samples
 
-    def _load_from_gl(self, beagle_path, bam_list_path, gl_mode="dosage"):
+    def _load_from_gl(
+        self,
+        beagle_path,
+        bam_list_path,
+        gl_mode="dosage",
+        gl_missing_threshold=0.4,
+        gl_min_maf=0.01,
+        gl_max_missing_frac=0.10,
+    ):
         """Load ANGSD genotype-likelihood data as a continuous-dosage matrix.
 
         Reads an ANGSD ``-doGlf 2`` beagle.gz file plus a paired bam_list
@@ -248,20 +256,35 @@ class DataLoaderMixin:
 
         - ``"dosage"`` (default): returns ``(n_sites_kept, n_samples)``.
           Each value is expected dosage E[geno] = P(AB) + 2*P(BB) under a
-          flat prior. Missing samples (max GL < 0.4) are imputed with
-          site-mean dosage. Site filter: ``min_maf=0.01``,
-          ``max_missing_frac=0.10``.
+          flat prior. Missing samples (max GL < ``gl_missing_threshold``) are
+          imputed with site-mean dosage, then sites are filtered by
+          ``gl_min_maf`` and ``gl_max_missing_frac``.
         - ``"full_gl"``: returns ``(3 * n_sites_kept, n_samples)``. Three
           pseudo-rows per genomic site holding the AA / AB / BB GL
           probabilities. Preserves genotype uncertainty information that
           the dosage scalar collapses. Missing samples are imputed with the
           per-site mean GL triplet.
 
-        Filter thresholds match those documented in the native GL loader
-        and are not currently surfaced as CLI flags.
+        Args:
+            gl_missing_threshold: A sample at a site is treated as missing if
+                ``max(GL_AA, GL_AB, GL_BB) < gl_missing_threshold``. Default 0.4.
+            gl_min_maf: Drop sites whose mean-dosage MAF falls below this.
+                Default 0.01.
+            gl_max_missing_frac: Drop sites whose fraction of missing samples
+                exceeds this. Default 0.10.
         """
         if gl_mode not in ("dosage", "full_gl"):
             raise ValueError(f"gl_mode must be 'dosage' or 'full_gl', got {gl_mode!r}")
+        if not 0.0 <= gl_missing_threshold <= 1.0:
+            raise ValueError(
+                f"gl_missing_threshold must be in [0, 1], got {gl_missing_threshold!r}"
+            )
+        if not 0.0 <= gl_max_missing_frac <= 1.0:
+            raise ValueError(
+                f"gl_max_missing_frac must be in [0, 1], got {gl_max_missing_frac!r}"
+            )
+        if gl_min_maf < 0.0:
+            raise ValueError(f"gl_min_maf must be >= 0, got {gl_min_maf!r}")
 
         sample_ids = _gl.sample_ids_from_bam_list(bam_list_path)
         n_samples = len(sample_ids)
@@ -271,16 +294,20 @@ class DataLoaderMixin:
         gl = _gl.reshape_gl(gl_flat, n_samples)
 
         dosage = _gl.expected_dosage(gl)
-        missing_mask = _gl.detect_missing(gl, gl_missing_threshold=0.4)
+        missing_mask = _gl.detect_missing(gl, gl_missing_threshold=gl_missing_threshold)
         dosage = _gl.impute_dosage_with_site_mean(dosage, missing_mask)
 
         keep, _reasons = _gl.filter_sites(
-            dosage, missing_mask, min_maf=0.01, max_missing_frac=0.10
+            dosage,
+            missing_mask,
+            min_maf=gl_min_maf,
+            max_missing_frac=gl_max_missing_frac,
         )
         if not keep.any():
             raise ValueError(
                 f"No sites passed the MAF/missingness filter "
-                f"(min_maf=0.01, max_missing_frac=0.10) on {beagle_path}."
+                f"(gl_min_maf={gl_min_maf}, gl_max_missing_frac={gl_max_missing_frac}) "
+                f"on {beagle_path}."
             )
 
         if gl_mode == "dosage":
@@ -310,6 +337,9 @@ class DataLoaderMixin:
         gl=None,
         bam_list=None,
         gl_mode="dosage",
+        gl_missing_threshold=0.4,
+        gl_min_maf=0.01,
+        gl_max_missing_frac=0.10,
     ):
         """Load genotype data from various input sources.
 
@@ -341,6 +371,14 @@ class DataLoaderMixin:
                 ``"full_gl"``. ``"dosage"`` returns one expected-dosage value
                 per site per sample; ``"full_gl"`` returns all three AA/AB/BB
                 GL probabilities as separate rows.
+            gl_missing_threshold (float): GL site filter; a sample at a site is
+                missing if ``max(GL_AA, GL_AB, GL_BB) < gl_missing_threshold``.
+                Ignored unless ``gl`` is set. Default 0.4.
+            gl_min_maf (float): GL site filter; drop sites whose mean-dosage MAF
+                falls below this. Ignored unless ``gl`` is set. Default 0.01.
+            gl_max_missing_frac (float): GL site filter; drop sites whose
+                fraction of missing samples exceeds this. Ignored unless ``gl``
+                is set. Default 0.10.
 
         Returns
         -------
@@ -436,7 +474,14 @@ class DataLoaderMixin:
                     "--gl / gl= requires a paired --bam_list / bam_list= "
                     "to derive sample IDs from the ANGSD BAM filelist."
                 )
-            return self._load_from_gl(gl, bam_list, gl_mode=gl_mode)
+            return self._load_from_gl(
+                gl,
+                bam_list,
+                gl_mode=gl_mode,
+                gl_missing_threshold=gl_missing_threshold,
+                gl_min_maf=gl_min_maf,
+                gl_max_missing_frac=gl_max_missing_frac,
+            )
 
         else:
             raise ValueError(

--- a/tests/test_gl_cli.py
+++ b/tests/test_gl_cli.py
@@ -89,6 +89,53 @@ def test_cli_gl_dosage_runs_end_to_end(tmp_path: Path):
     )
 
 
+def test_cli_gl_threshold_flags_run_end_to_end(tmp_path: Path):
+    beagle = tmp_path / "out.beagle.gz"
+    bam_list = tmp_path / "bams.txt"
+    sample_data = tmp_path / "samples.tsv"
+    _write_synthetic_beagle(beagle, n_sites=100, n_samples=6, seed=2)
+    _write_bam_list(bam_list, [f"Ind{i}" for i in range(6)])
+    _write_sample_data(sample_data, [f"Ind{i}" for i in range(6)])
+
+    out_prefix = tmp_path / "out" / "run"
+
+    proc = subprocess.run(
+        _cmd_prefix()
+        + [
+            "--gl",
+            str(beagle),
+            "--bam_list",
+            str(bam_list),
+            "--gl_min_maf",
+            "0.05",
+            "--gl_max_missing_frac",
+            "0.25",
+            "--gl_missing_threshold",
+            "0.5",
+            "--sample_data",
+            str(sample_data),
+            "--out",
+            str(out_prefix),
+            "--max_epochs",
+            "2",
+            "--patience",
+            "2",
+            "--train_split",
+            "0.5",
+            "--seed",
+            "1",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert proc.returncode == 0, f"stderr:\n{proc.stderr}\nstdout:\n{proc.stdout}"
+    expected_predlocs = out_prefix.parent / "run_predlocs.txt"
+    assert expected_predlocs.exists(), (
+        f"Expected {expected_predlocs} — stderr:\n{proc.stderr}\nstdout:\n{proc.stdout}"
+    )
+
+
 def test_cli_gl_without_bam_list_errors(tmp_path: Path):
     beagle = tmp_path / "out.beagle.gz"
     sample_data = tmp_path / "samples.tsv"

--- a/tests/test_gl_input.py
+++ b/tests/test_gl_input.py
@@ -167,3 +167,87 @@ def test_load_from_gl_all_sites_filtered_raises(tmp_path):
     loc = Locator({"sample_data": str(sample_data)})
     with pytest.raises(ValueError, match="[Nn]o sites"):
         loc.load_genotypes(gl=str(beagle), bam_list=str(bam_list))
+
+
+def test_load_from_gl_defaults_match_explicit_defaults(tmp_path):
+    """Calling with no threshold kwargs must equal passing the documented defaults."""
+    beagle = tmp_path / "out.beagle.gz"
+    bam_list = tmp_path / "bams.txt"
+    sample_data = tmp_path / "samples.tsv"
+    _write_synthetic_beagle(beagle, n_sites=30, n_samples=5, seed=7)
+    _write_bam_list(bam_list, [f"Ind{i}" for i in range(5)])
+    _write_sample_data(sample_data, [f"Ind{i}" for i in range(5)])
+
+    loc = Locator({"sample_data": str(sample_data)})
+    implicit, _ = loc.load_genotypes(gl=str(beagle), bam_list=str(bam_list))
+    explicit, _ = loc.load_genotypes(
+        gl=str(beagle),
+        bam_list=str(bam_list),
+        gl_missing_threshold=0.4,
+        gl_min_maf=0.01,
+        gl_max_missing_frac=0.10,
+    )
+    np.testing.assert_array_equal(implicit, explicit)
+
+
+@pytest.mark.parametrize(
+    "seed, permissive_kwargs, strict_kwargs, strictly_fewer",
+    [
+        # A higher gl_min_maf removes more low-frequency sites; with
+        # Dirichlet-uniform GLs the strict cutoff drops at least one.
+        (11, {"gl_min_maf": 0.0}, {"gl_min_maf": 0.4}, True),
+        # gl_missing_threshold=0.6 forces near-uniform GLs to count as missing
+        # so gl_max_missing_frac actually bites. Monotone, but not guaranteed
+        # to drop a site on this synthetic data, so only assert <=.
+        (
+            13,
+            {"gl_missing_threshold": 0.6, "gl_min_maf": 0.0, "gl_max_missing_frac": 1.0},
+            {"gl_missing_threshold": 0.6, "gl_min_maf": 0.0, "gl_max_missing_frac": 0.0},
+            False,
+        ),
+    ],
+)
+def test_load_from_gl_stricter_filter_drops_more_sites(
+    tmp_path, seed, permissive_kwargs, strict_kwargs, strictly_fewer
+):
+    """A stricter threshold keeps no more sites than a permissive one."""
+    beagle = tmp_path / "out.beagle.gz"
+    bam_list = tmp_path / "bams.txt"
+    sample_data = tmp_path / "samples.tsv"
+    _write_synthetic_beagle(beagle, n_sites=40, n_samples=6, seed=seed)
+    _write_bam_list(bam_list, [f"Ind{i}" for i in range(6)])
+    _write_sample_data(sample_data, [f"Ind{i}" for i in range(6)])
+
+    loc = Locator({"sample_data": str(sample_data)})
+    permissive, _ = loc.load_genotypes(
+        gl=str(beagle), bam_list=str(bam_list), **permissive_kwargs
+    )
+    strict, _ = loc.load_genotypes(
+        gl=str(beagle), bam_list=str(bam_list), **strict_kwargs
+    )
+    assert strict.shape[0] <= permissive.shape[0]
+    if strictly_fewer:
+        assert strict.shape[0] < permissive.shape[0]
+
+
+@pytest.mark.parametrize(
+    "kwargs, match",
+    [
+        ({"gl_min_maf": -0.1}, "gl_min_maf"),
+        ({"gl_max_missing_frac": 2.0}, "gl_max_missing_frac"),
+        ({"gl_max_missing_frac": -0.5}, "gl_max_missing_frac"),
+        ({"gl_missing_threshold": -1.0}, "gl_missing_threshold"),
+        ({"gl_missing_threshold": 1.5}, "gl_missing_threshold"),
+    ],
+)
+def test_load_from_gl_out_of_range_thresholds_raise(tmp_path, kwargs, match):
+    beagle = tmp_path / "out.beagle.gz"
+    bam_list = tmp_path / "bams.txt"
+    sample_data = tmp_path / "samples.tsv"
+    _write_synthetic_beagle(beagle, n_sites=5, n_samples=3, seed=17)
+    _write_bam_list(bam_list, [f"Ind{i}" for i in range(3)])
+    _write_sample_data(sample_data, [f"Ind{i}" for i in range(3)])
+
+    loc = Locator({"sample_data": str(sample_data)})
+    with pytest.raises(ValueError, match=match):
+        loc.load_genotypes(gl=str(beagle), bam_list=str(bam_list), **kwargs)


### PR DESCRIPTION
## Summary

Follow-up to the native `--gl` loader (#47). That loader hard-coded its three
site-filtering thresholds in `_load_from_gl`; this PR surfaces them as
`load_genotypes()` keywords and `--gl_*` CLI flags so users can tune filtering
without editing source. **The current values remain the defaults, so behavior
is unchanged for anyone who does not set them.**

| Threshold | CLI flag | `load_genotypes` kwarg | Default |
|---|---|---|---|
| missingness call | `--gl_missing_threshold` | `gl_missing_threshold` | 0.4 |
| max missing fraction | `--gl_max_missing_frac` | `gl_max_missing_frac` | 0.10 |
| min MAF | `--gl_min_maf` | `gl_min_maf` | 0.01 |

The implementation mirrors the existing `microsat_min_allele_freq` /
`--microsat_maf` precedent: one kwarg per knob, threaded
`load_genotypes` -> `_load_from_gl` -> the `_gl` helpers
(`detect_missing`, `filter_sites`), which already accept these as parameters.

## Changes

- `locator/loaders.py` - `_load_from_gl` and `load_genotypes` gain the three
  kwargs; range validation runs early (before the beagle read) so a bad value
  fails fast for both CLI and Python-API callers.
- `locator/cli.py` - `--gl_min_maf`, `--gl_max_missing_frac`,
  `--gl_missing_threshold` flags, grouped with the sibling `--gl` flags and
  forwarded in `main()`.
- `docs/genotype_likelihoods.md` - Site filtering section now documents the
  flags and Python kwargs (replacing the old "edit the source" note) with CLI
  and API override examples.
- `tests/test_gl_input.py` - loader-level tests: defaults reproduce the implicit
  call, stricter thresholds drop no more sites (parametrized over MAF and
  missingness), and out-of-range values raise `ValueError`.
- `tests/test_gl_cli.py` - end-to-end subprocess run passing the three flags.

## Test plan

- [x] `pixi run pytest tests/test_gl_helpers.py tests/test_gl_input.py tests/test_gl_cli.py -n auto` - 32 passed.
- [x] `pixi run ruff check locator/ tests/` and `ruff format --check` clean.
- [x] Defaults unchanged: running without any `--gl_*` flag reproduces the
      pre-PR loader output (guarded by `test_load_from_gl_defaults_match_explicit_defaults`).