### PR TITLE
feat(gl): support genotype-likelihood dosage in windowed analysis

### DIFF
--- a/locator/_gl.py
+++ b/locator/_gl.py
@@ -57,6 +57,41 @@ def load_beagle(beagle_path):
     return markers, gl_flat
 
 
+def parse_markers(markers):
+    """Parse beagle ``chrom_pos`` marker strings into chromosomes and positions.
+
+    ANGSD beagle ``marker`` entries encode the genomic site as
+    ``<chrom>_<pos>`` (e.g. ``chr01_2039``). Chromosome names may themselves
+    contain underscores (e.g. ``scaffold_12_2039``), so the split is on the
+    LAST underscore only.
+
+    Returns
+    -------
+    chromosomes : np.ndarray (object), length n_sites
+    positions : np.ndarray (int64), length n_sites
+    """
+    chroms = []
+    positions = []
+    bad = []
+    for m in markers:
+        chrom, sep, pos_str = m.rpartition("_")
+        if not sep:
+            bad.append(m)
+            continue
+        try:
+            positions.append(int(pos_str))
+        except ValueError:
+            bad.append(m)
+            continue
+        chroms.append(chrom)
+    if bad:
+        raise ValueError(
+            f"Could not parse {len(bad)} beagle marker(s) as 'chrom_pos'; "
+            f"first offenders: {bad[:10]}"
+        )
+    return np.array(chroms, dtype=object), np.array(positions, dtype=np.int64)
+
+
 def validate_dimensions(gl_flat, n_samples, beagle_path, bam_list_path):
     expected_cols = n_samples * 3
     if gl_flat.shape[1] != expected_cols:

--- a/locator/analysis/windowed.py
+++ b/locator/analysis/windowed.py
@@ -6,6 +6,7 @@ from tensorflow import keras
 from tqdm import tqdm
 
 from ..data import IndexSet, normalize_locs
+from ..data.filters import is_dosage_matrix
 
 
 class WindowedMixin:
@@ -89,7 +90,10 @@ class WindowedMixin:
         if len(windows) > 0:
             first_window_indices = windows[0]["indices"]
             if np.sum(first_window_indices) > 0:
-                window_genos = genotypes[first_window_indices, :, :]
+                if is_dosage_matrix(genotypes):
+                    window_genos = genotypes[first_window_indices, :]
+                else:
+                    window_genos = genotypes[first_window_indices, :, :]
                 self.train(genotypes=window_genos, samples=samples, na_action=na_action)
 
         # Create lists to store predictions
@@ -99,7 +103,10 @@ class WindowedMixin:
         for window in tqdm(windows):
             if window["n_snps"] > 0:
                 # Get genotypes for this window
-                window_genos = genotypes[window["indices"], :, :]
+                if is_dosage_matrix(genotypes):
+                    window_genos = genotypes[window["indices"], :]
+                else:
+                    window_genos = genotypes[window["indices"], :, :]
 
                 # Clear existing model and weights
                 self.model = None

--- a/locator/loaders.py
+++ b/locator/loaders.py
@@ -289,7 +289,7 @@ class DataLoaderMixin:
         sample_ids = _gl.sample_ids_from_bam_list(bam_list_path)
         n_samples = len(sample_ids)
 
-        _markers, gl_flat = _gl.load_beagle(beagle_path)
+        markers, gl_flat = _gl.load_beagle(beagle_path)
         _gl.validate_dimensions(gl_flat, n_samples, beagle_path, bam_list_path)
         gl = _gl.reshape_gl(gl_flat, n_samples)
 
@@ -312,6 +312,14 @@ class DataLoaderMixin:
 
         if gl_mode == "dosage":
             out = dosage[keep, :].astype(np.float32, copy=False)
+            # Derive per-site positions/chromosomes from the kept beagle markers
+            # so windowed analysis has coordinates (1:1 with the dosage rows).
+            # full_gl emits 3 rows per site and cannot align to a single
+            # position array, so positions are left unset there.
+            chroms_all, pos_all = _gl.parse_markers(markers)
+            self.chromosomes = chroms_all[keep]
+            self.positions = pos_all[keep]
+            self._report_variant_metadata()
         else:  # full_gl
             gl_imputed = _gl.impute_gl_with_site_mean(gl, missing_mask)
             kept_gl = gl_imputed[keep, :, :]  # (n_kept, n_samples, 3)

--- a/locator/parallel/_actor.py
+++ b/locator/parallel/_actor.py
@@ -192,11 +192,18 @@ class WindowActor:
         self._locator = _create_worker_locator(self._data, "actor")
         self._base_out = self._data["config"]["out"]
 
-        # Materialise the full GenotypeArray once on the actor; window calls
-        # only slice ``window_snp_indices`` off it.
-        import allel
+        # Materialise the full genotypes once on the actor; window calls only
+        # slice ``window_snp_indices`` off it. Continuous-dosage (GL) input is a
+        # 2D float matrix and is kept as-is; hard calls become a GenotypeArray.
+        from locator.data.filters import is_dosage_matrix
 
-        self._genotypes = allel.GenotypeArray(self._data["genotypes_array"])
+        arr = self._data["genotypes_array"]
+        if is_dosage_matrix(arr):
+            self._genotypes = arr
+        else:
+            import allel
+
+            self._genotypes = allel.GenotypeArray(arr)
 
         loc = self._locator
         loc.genotypes = self._genotypes

--- a/locator/parallel/windowed.py
+++ b/locator/parallel/windowed.py
@@ -20,6 +20,8 @@ import pandas as pd
 import ray
 from ray.util import ActorPool
 
+from locator.data.filters import is_dosage_matrix
+
 from ._actor import DEFAULT_GPU_MEM_MB, make_window_actors
 from ._helpers import (
     _ensure_ray_initialized,
@@ -263,9 +265,12 @@ def parallel_windows_holdouts(  # noqa: C901
         # Note: windowed analysis must materialize the full genotype array on
         # the actor because every window slices a different SNP subset; we
         # can't pre-filter to a small array as the other dispatchers do.
+        # Continuous-dosage (GL) input is a bare 2D ndarray with no ``.values``;
+        # ship it directly. Hard-call inputs are GenotypeArray/DataFrame-like.
+        genotypes_array = genotypes if is_dosage_matrix(genotypes) else genotypes.values
         data_ref = ray.put(
             {
-                "genotypes_array": genotypes.values,
+                "genotypes_array": genotypes_array,
                 "samples": samples,
                 "sample_data": sample_data,
                 "config": locator.config,

--- a/locator/training.py
+++ b/locator/training.py
@@ -817,7 +817,12 @@ class TrainingMixin:
         self.samples = samples
         self.index_set = index_set
 
-        window_genotypes = genotypes[window_snp_indices, :, :]
+        # Continuous-dosage (GL) input is 2D (n_sites, n_samples); hard calls
+        # are 3D (n_sites, n_samples, ploidy). Slice on the right rank.
+        if is_dosage_matrix(genotypes):
+            window_genotypes = genotypes[window_snp_indices, :]
+        else:
+            window_genotypes = genotypes[window_snp_indices, :, :]
         self._filter_genotypes(window_genotypes)
 
         # Store filtered data shape

--- a/tests/test_gl_helpers.py
+++ b/tests/test_gl_helpers.py
@@ -71,6 +71,26 @@ def test_load_beagle_empty_raises(tmp_path):
         _gl.load_beagle(beagle)
 
 
+def test_parse_markers_basic():
+    chroms, positions = _gl.parse_markers(["chr1_100", "chr1_200", "chr2_5"])
+    np.testing.assert_array_equal(chroms, np.array(["chr1", "chr1", "chr2"]))
+    np.testing.assert_array_equal(positions, np.array([100, 200, 5]))
+    assert positions.dtype == np.int64
+
+
+def test_parse_markers_underscore_in_chromosome():
+    # chromosome names may contain underscores; only the last is the separator.
+    chroms, positions = _gl.parse_markers(["scaffold_12_2039"])
+    assert list(chroms) == ["scaffold_12"]
+    assert list(positions) == [2039]
+
+
+@pytest.mark.parametrize("bad", [["chr1"], ["chr1_x"], ["chr1_100", "noUnderscore"]])
+def test_parse_markers_unparseable_raises(bad):
+    with pytest.raises(ValueError, match="Could not parse"):
+        _gl.parse_markers(bad)
+
+
 def test_validate_dimensions_pass():
     gl_flat = np.zeros((10, 9), dtype=np.float32)
     _gl.validate_dimensions(

--- a/tests/test_gl_input.py
+++ b/tests/test_gl_input.py
@@ -251,3 +251,99 @@ def test_load_from_gl_out_of_range_thresholds_raise(tmp_path, kwargs, match):
     loc = Locator({"sample_data": str(sample_data)})
     with pytest.raises(ValueError, match=match):
         loc.load_genotypes(gl=str(beagle), bam_list=str(bam_list), **kwargs)
+
+
+def _write_controlled_beagle(path: Path, rows: list[tuple[str, list[float]]]) -> None:
+    """Write a beagle with explicit marker names and GL triplets per sample.
+
+    Each row is (marker, flat_gl) where flat_gl is n_samples*3 values.
+    """
+    n_cols = len(rows[0][1])
+    n_samples = n_cols // 3
+    header = ["marker", "allele1", "allele2"]
+    for s in range(n_samples):
+        header += [f"Ind{s}", f"Ind{s}", f"Ind{s}"]
+    lines = ["\t".join(header)]
+    for marker, gl in rows:
+        lines.append("\t".join([marker, "A", "C"] + [f"{v:.6f}" for v in gl]))
+    with gzip.open(path, "wb") as fh:
+        fh.write(("\n".join(lines) + "\n").encode())
+
+
+def test_load_from_gl_dosage_sets_positions_for_kept_sites(tmp_path):
+    beagle = tmp_path / "out.beagle.gz"
+    bam_list = tmp_path / "bams.txt"
+    sample_data = tmp_path / "samples.tsv"
+    ids = ["Ind0", "Ind1", "Ind2"]
+    het = [0.0, 1.0, 0.0] * 3  # all-AB: dosage 1, MAF 0.5 -> kept
+    mono = [1.0, 0.0, 0.0] * 3  # all-AA: dosage 0, MAF 0 -> dropped
+    _write_controlled_beagle(
+        beagle,
+        [("chr1_10", het), ("chr1_20", het), ("chr1_30", mono), ("chr2_5", het)],
+    )
+    _write_bam_list(bam_list, ids)
+    _write_sample_data(sample_data, ids)
+
+    loc = Locator({"sample_data": str(sample_data)})
+    genotypes, _ = loc.load_genotypes(gl=str(beagle), bam_list=str(bam_list))
+
+    # site chr1_30 is monomorphic and filtered out; positions track kept sites.
+    assert loc.positions is not None
+    assert len(loc.positions) == genotypes.shape[0]
+    np.testing.assert_array_equal(loc.positions, np.array([10, 20, 5]))
+    np.testing.assert_array_equal(
+        np.asarray(loc.chromosomes), np.array(["chr1", "chr1", "chr2"], dtype=object)
+    )
+    assert 30 not in loc.positions
+
+
+def test_load_from_gl_full_gl_leaves_positions_unset(tmp_path):
+    beagle = tmp_path / "out.beagle.gz"
+    bam_list = tmp_path / "bams.txt"
+    sample_data = tmp_path / "samples.tsv"
+    _write_synthetic_beagle(beagle, n_sites=10, n_samples=4, seed=3)
+    _write_bam_list(bam_list, [f"Ind{i}" for i in range(4)])
+    _write_sample_data(sample_data, [f"Ind{i}" for i in range(4)])
+
+    loc = Locator({"sample_data": str(sample_data)})
+    loc.load_genotypes(gl=str(beagle), bam_list=str(bam_list), gl_mode="full_gl")
+    # full_gl emits 3 rows per site, so per-site positions cannot align 1:1.
+    assert getattr(loc, "positions", None) is None
+
+
+@pytest.mark.slow
+def test_run_windows_holdouts_on_gl_dosage(tmp_path):
+    """End-to-end: GL dosage flows through sequential windowed holdouts."""
+    beagle = tmp_path / "out.beagle.gz"
+    bam_list = tmp_path / "bams.txt"
+    sample_data = tmp_path / "samples.tsv"
+    ids = [f"Ind{i}" for i in range(8)]
+    _write_synthetic_beagle(beagle, n_sites=30, n_samples=8, seed=5)
+    _write_bam_list(bam_list, ids)
+    _write_sample_data(sample_data, ids)
+
+    loc = Locator(
+        {
+            "sample_data": str(sample_data),
+            "keras_verbose": 0,
+            "max_epochs": 2,
+            "patience": 1,
+            "out": str(tmp_path / "gl_win"),
+        }
+    )
+    genotypes, samples = loc.load_genotypes(gl=str(beagle), bam_list=str(bam_list))
+    assert loc.positions is not None  # set by the GL loader from markers
+
+    # positions are 0..29 (chr1_<i>), so a 10bp window yields multiple windows.
+    result = loc.run_windows_holdouts(
+        genotypes=genotypes,
+        samples=samples,
+        k=2,
+        window_size=10,
+        return_df=True,
+        save_full_pred_matrix=False,
+    )
+    assert result is not None
+    x_cols = [c for c in result.columns if c.startswith("x_")]
+    assert len(x_cols) > 0
+    assert len(result) == 2  # k holdout samples

--- a/tests/test_parallel_windowed.py
+++ b/tests/test_parallel_windowed.py
@@ -85,3 +85,60 @@ def test_parallel_windows_holdouts_cpu_smoke(small_data_with_positions):
     assert os.path.exists(chunk_path)
     chunks = pd.read_csv(chunk_path)
     assert chunks["window_label"].nunique() >= 1
+
+
+@pytest.fixture
+def small_dosage_with_positions(tmp_path):
+    """A 2D float dosage matrix (GL-style) with injected positions."""
+    rng = np.random.default_rng(0)
+    n_snps, n_samples = 100, 20
+    dosage = rng.uniform(0.0, 2.0, size=(n_snps, n_samples)).astype(np.float32)
+    samples = np.array([f"s{i}" for i in range(n_samples)], dtype=object)
+    sample_file = tmp_path / "samples.txt"
+    content = "sampleID\tx\ty\n"
+    for i, sid in enumerate(samples):
+        content += f"{sid}\t{float(i)}\t{float(i * 2)}\n"
+    sample_file.write_text(content)
+
+    config = {
+        "out": str(tmp_path / "win_dosage_test"),
+        "sample_data": str(sample_file),
+        "max_epochs": 2,
+        "patience": 1,
+        "batch_size": 4,
+        "width": 16,
+        "nlayers": 2,
+        "keras_verbose": 0,
+        "verbose_splits": False,
+        "holdout_no_intermediate_saves": True,
+        "save_fold_models": False,
+        "min_snps_per_window": 5,
+    }
+    loc = Locator(config)
+    loc.positions = np.arange(1, n_snps + 1) * 1000
+    return loc, dosage, samples, tmp_path
+
+
+@pytest.mark.slow
+def test_parallel_windows_holdouts_dosage_cpu_smoke(small_dosage_with_positions):
+    """GL dosage matrix flows through the parallel windowed path on CPU."""
+    loc, dosage, samples, tmp_path = small_dosage_with_positions
+    df = parallel_windows_holdouts(
+        locator=loc,
+        genotypes=dosage,  # bare 2D float ndarray, no .values
+        samples=samples,
+        window_start=0,
+        window_size=50_000,
+        respect_chromosomes=False,
+        holdout_indices=list(range(0, 4)),
+        gpu_ids=[],
+        gpu_fraction=0.0,
+        return_df=True,
+        save_full_pred_matrix=True,
+        verbose=False,
+    )
+    assert df is not None
+    assert "sampleID" in df.columns
+    x_cols = [c for c in df.columns if c.startswith("x_")]
+    y_cols = [c for c in df.columns if c.startswith("y_")]
+    assert len(x_cols) >= 1 and len(y_cols) == len(x_cols)


### PR DESCRIPTION
First of three stacked PRs for #60 (Option A: dosage-aware windowed analysis).

## Summary

The parallel/sequential windowed paths assumed hard-call `allel.GenotypeArray`
data and positions from VCF/zarr, so GL dosage input from
`load_genotypes(gl=..., bam_list=...)` could not run windowed analysis. This PR
teaches the windowed path to accept the 2D float dosage matrix and derives
per-site coordinates from the beagle `marker` column.

## Changes

- **`_gl.parse_markers`** - parse `chrom_pos` beagle markers (e.g. `chr01_2039`)
  into chromosomes + int positions, splitting on the **last** underscore so
  scaffold names that contain underscores (`scaffold_12_2039`) parse correctly.
- **`_load_from_gl` (dosage mode)** - set `self.positions` / `self.chromosomes`
  from the kept-site markers, aligned 1:1 with the dosage rows.
  `_load_positions` / `_ensure_positions` early-return when positions are set,
  so no GL branch is needed there. `full_gl` leaves positions unset (3 rows per
  site cannot align 1:1) - documented.
- Branch the three dosage failure points on `is_dosage_matrix`
  (`data/filters.py:146`): the `ray.put` `.values` access
  (`parallel/windowed.py`), the `allel.GenotypeArray` rebuild in `WindowActor`
  (`parallel/_actor.py`), and the `train_window` slice (`training.py`). The
  `train_window` fix also enables the **sequential** `run_windows_holdouts`; the
  two `run_windows` slices in `analysis/windowed.py` get the same branch.

Prediction is already dosage-aware (`prediction.py`), and `_filter_genotypes`
already dispatches dosage to `filter_dosage_matrix`, so no change there.

## Test plan

- [x] `parse_markers` unit tests (happy path, underscore-in-chromosome, unparseable raises).
- [x] `_load_from_gl` dosage sets positions for kept sites (a filtered low-MAF site's position is absent); `full_gl` leaves positions unset.
- [x] End-to-end (slow, CPU): sequential `run_windows_holdouts` on GL dosage, and a `parallel_windows_holdouts` dosage CPU smoke test.
- [x] Regression: all 13 hard-call `test_windows.py` tests still pass.
- [x] `ruff check` + `ruff format --check` clean.

## Follow-ups (rest of #60)

- PR2: `beagle_to_zarr` converter + a dosage branch in the zarr loader.
- PR3: `parallel_windows_leave_one_out` (full LOO per window). #60 closes with PR3.