### PR TITLE
feat(gl): add beagle_to_zarr converter and zarr dosage loader

### DIFF
--- a/locator/loaders.py
+++ b/locator/loaders.py
@@ -48,7 +48,9 @@ class DataLoaderMixin:
     def _load_from_zarr(self, zarr_path):
         """Load genotypes from zarr file.
 
-        Supports both scikit-allel format (calldata/GT, samples) and
+        Supports three layouts: a continuous-dosage store written by
+        ``beagle_to_zarr`` (a ``dosage`` array + ``variants/POS``/
+        ``variants/CHROM``), scikit-allel format (calldata/GT, samples), and
         VCF Zarr / bio2zarr format (call_genotype, sample_id).
 
         Args:
@@ -57,11 +59,25 @@ class DataLoaderMixin:
         Returns
         -------
             tuple: (genotypes, samples) where:
-                - genotypes is an allel.GenotypeArray containing genetic data
+                - genotypes is an allel.GenotypeArray for hard-call stores, or a
+                  2D float32 dosage ndarray (n_sites, n_samples) for dosage stores
                 - samples is a numpy array of sample IDs
         """
         print("reading zarr")
         callset = zarr.open_group(zarr_path, mode="r")
+
+        if "dosage" in callset or callset.attrs.get("locator_format") == "dosage":
+            # Continuous-dosage (GL) store. Return the 2D float matrix directly;
+            # positions/chromosomes come from the store so windowed analysis
+            # works through the same path as VCF/zarr hard-call input.
+            dosage = np.asarray(callset["dosage"][:], dtype=np.float32)
+            samples = np.array([str(x) for x in callset["samples"][:]], dtype=object)
+            self.positions = np.asarray(callset["variants/POS"][:])
+            self.chromosomes = np.array(
+                [str(x) for x in callset["variants/CHROM"][:]], dtype=object
+            )
+            self._report_variant_metadata()
+            return dosage, samples
 
         if "call_genotype" in callset:
             # bio2zarr / VCF Zarr format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ fast-vcf = [
 [project.scripts]
 locator = "locator.cli:main"
 vcf_to_zarr = "scripts.vcf_to_zarr:main"
+beagle_to_zarr = "scripts.beagle_to_zarr:main"
 
 [project.urls]
 Homepage = "https://github.com/kr-colab/ReLocator"
@@ -74,6 +75,9 @@ include = ["locator*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+# Put the repo root on sys.path so tests can import the `scripts` package
+# (e.g. scripts.beagle_to_zarr), which is not part of the installed wheel.
+pythonpath = ["."]
 python_files = ["test_*.py", "*_test.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]

--- a/scripts/beagle_to_zarr.py
+++ b/scripts/beagle_to_zarr.py
@@ -1,0 +1,125 @@
+"""Convert an ANGSD beagle GL file to a continuous-dosage zarr store.
+
+Reads a ``-doGlf 2`` beagle.gz plus its paired bam_list, computes expected
+dosage with the same impute/filter pipeline as the native ``--gl`` loader, and
+writes a zarr store holding the dosage matrix plus ``variants/POS`` and
+``variants/CHROM`` parsed from the beagle marker column. The resulting store
+loads via ``load_genotypes(zarr=...)`` and carries the per-site positions that
+windowed analysis needs.
+"""
+
+import argparse
+
+import numpy as np
+import zarr
+
+from locator import _gl
+
+
+def beagle_to_zarr(
+    beagle,
+    bam_list,
+    out_zarr,
+    gl_missing_threshold=0.4,
+    gl_min_maf=0.01,
+    gl_max_missing_frac=0.10,
+    chunk_sites=10000,
+    overwrite=False,
+):
+    """Write a continuous-dosage zarr store from a beagle GL file.
+
+    The dosage / imputation / site-filter steps mirror
+    ``DataLoaderMixin._load_from_gl`` so the stored matrix is identical to what
+    ``load_genotypes(gl=..., gl_mode="dosage")`` would return.
+    """
+    sample_ids = _gl.sample_ids_from_bam_list(bam_list)
+    n_samples = len(sample_ids)
+
+    markers, gl_flat = _gl.load_beagle(beagle)
+    _gl.validate_dimensions(gl_flat, n_samples, beagle, bam_list)
+    gl = _gl.reshape_gl(gl_flat, n_samples)
+
+    dosage = _gl.expected_dosage(gl)
+    missing_mask = _gl.detect_missing(gl, gl_missing_threshold=gl_missing_threshold)
+    dosage = _gl.impute_dosage_with_site_mean(dosage, missing_mask)
+
+    keep, _reasons = _gl.filter_sites(
+        dosage,
+        missing_mask,
+        min_maf=gl_min_maf,
+        max_missing_frac=gl_max_missing_frac,
+    )
+    if not keep.any():
+        raise ValueError(
+            f"No sites passed the MAF/missingness filter "
+            f"(gl_min_maf={gl_min_maf}, gl_max_missing_frac={gl_max_missing_frac}) "
+            f"on {beagle}."
+        )
+
+    dosage = dosage[keep, :].astype(np.float32, copy=False)
+    chroms_all, pos_all = _gl.parse_markers(markers)
+    chroms = chroms_all[keep]
+    positions = pos_all[keep]
+
+    n_sites = dosage.shape[0]
+    root = zarr.open_group(out_zarr, mode="w" if overwrite else "w-")
+    root.attrs["locator_format"] = "dosage"
+    # Chunk along the sites axis only: windowed analysis slices rows (sites),
+    # and every read needs all samples for a site.
+    root.create_array(
+        "dosage",
+        data=dosage,
+        chunks=(min(chunk_sites, n_sites), n_samples),
+    )
+    variants = root.create_group("variants")
+    variants.create_array("POS", data=positions.astype(np.int64))
+    variants.create_array("CHROM", data=np.array([str(c) for c in chroms], dtype=str))
+    root.create_array("samples", data=np.array(sample_ids, dtype=str))
+
+    print(
+        f"Wrote {out_zarr}: dosage {dosage.shape} (float32), "
+        f"{n_sites} sites x {n_samples} samples.",
+        flush=True,
+    )
+    return out_zarr
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Convert an ANGSD beagle GL file to a dosage zarr store."
+    )
+    parser.add_argument("--beagle", required=True, help="ANGSD beagle.gz file")
+    parser.add_argument(
+        "--bam_list",
+        required=True,
+        help="BAM file list used in the ANGSD run (one path per line)",
+    )
+    parser.add_argument("--zarr", required=True, help="path for zarr output")
+    parser.add_argument("--gl_min_maf", type=float, default=0.01)
+    parser.add_argument("--gl_max_missing_frac", type=float, default=0.10)
+    parser.add_argument("--gl_missing_threshold", type=float, default=0.4)
+    parser.add_argument(
+        "--chunk_sites",
+        type=int,
+        default=10000,
+        help="zarr chunk size along the sites axis. default: 10000",
+    )
+    parser.add_argument(
+        "--overwrite", action="store_true", help="overwrite existing zarr store"
+    )
+    args = parser.parse_args(argv)
+    beagle_to_zarr(
+        args.beagle,
+        args.bam_list,
+        args.zarr,
+        gl_missing_threshold=args.gl_missing_threshold,
+        gl_min_maf=args.gl_min_maf,
+        gl_max_missing_frac=args.gl_max_missing_frac,
+        chunk_sites=args.chunk_sites,
+        overwrite=args.overwrite,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_beagle_to_zarr.py
+++ b/tests/test_beagle_to_zarr.py
@@ -1,0 +1,112 @@
+"""Tests for the beagle -> dosage-zarr converter and the zarr dosage loader."""
+
+from __future__ import annotations
+
+import gzip
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from locator.core import Locator
+from locator.data.filters import is_dosage_matrix
+from scripts.beagle_to_zarr import beagle_to_zarr
+
+
+def _write_bam_list(path: Path, ids: list[str]) -> None:
+    path.write_text("\n".join(f"/data/{sid}.bam" for sid in ids) + "\n")
+
+
+def _write_synthetic_beagle(path: Path, n_sites: int, n_samples: int, seed: int) -> None:
+    rng = np.random.default_rng(seed)
+    header = ["marker", "allele1", "allele2"]
+    for s in range(n_samples):
+        header += [f"Ind{s}", f"Ind{s}", f"Ind{s}"]
+    lines = ["\t".join(header)]
+    for i in range(n_sites):
+        flat = rng.dirichlet(np.ones(3), size=n_samples).flatten()
+        lines.append(
+            "\t".join([f"chr1_{i * 100}", "A", "C"] + [f"{v:.6f}" for v in flat])
+        )
+    with gzip.open(path, "wb") as fh:
+        fh.write(("\n".join(lines) + "\n").encode())
+
+
+def _write_sample_data(path: Path, ids: list[str]) -> None:
+    rows = ["sampleID\tx\ty"]
+    for i, sid in enumerate(ids):
+        rows.append(f"{sid}\t{float(i)}\t{float(i * 2)}")
+    path.write_text("\n".join(rows) + "\n")
+
+
+@pytest.fixture
+def beagle_inputs(tmp_path):
+    beagle = tmp_path / "out.beagle.gz"
+    bam_list = tmp_path / "bams.txt"
+    sample_data = tmp_path / "samples.tsv"
+    ids = [f"Ind{i}" for i in range(5)]
+    _write_synthetic_beagle(beagle, n_sites=30, n_samples=5, seed=7)
+    _write_bam_list(bam_list, ids)
+    _write_sample_data(sample_data, ids)
+    return beagle, bam_list, sample_data, ids
+
+
+def test_converter_writes_expected_layout(tmp_path, beagle_inputs):
+    import zarr
+
+    beagle, bam_list, _sd, ids = beagle_inputs
+    out = tmp_path / "store.zarr"
+    beagle_to_zarr(str(beagle), str(bam_list), str(out), chunk_sites=8)
+
+    root = zarr.open_group(str(out), mode="r")
+    assert root.attrs.get("locator_format") == "dosage"
+    dosage = root["dosage"]
+    n_sites, n_samples = dosage.shape
+    assert n_samples == 5
+    assert dosage.dtype == np.float32
+    assert dosage.chunks == (8, 5)  # chunked along the sites axis only
+    assert root["variants/POS"].shape == (n_sites,)
+    assert np.issubdtype(np.asarray(root["variants/POS"][:]).dtype, np.integer)
+    assert root["variants/CHROM"].shape == (n_sites,)
+    assert [str(s) for s in root["samples"][:]] == ids
+
+
+def test_converter_matches_native_gl_loader(tmp_path, beagle_inputs):
+    """Converter dosage must equal load_genotypes(gl=..., gl_mode='dosage')."""
+    beagle, bam_list, sample_data, _ids = beagle_inputs
+    out = tmp_path / "store.zarr"
+    beagle_to_zarr(str(beagle), str(bam_list), str(out))
+
+    loc_zarr = Locator({"sample_data": str(sample_data)})
+    g_zarr, s_zarr = loc_zarr.load_genotypes(zarr=str(out))
+    loc_gl = Locator({"sample_data": str(sample_data)})
+    g_gl, s_gl = loc_gl.load_genotypes(gl=str(beagle), bam_list=str(bam_list))
+
+    np.testing.assert_array_equal(g_zarr, g_gl)
+    assert list(s_zarr) == list(s_gl)
+
+
+def test_zarr_dosage_loads_as_dosage_with_positions(tmp_path, beagle_inputs):
+    beagle, bam_list, sample_data, _ids = beagle_inputs
+    out = tmp_path / "store.zarr"
+    beagle_to_zarr(str(beagle), str(bam_list), str(out))
+
+    loc = Locator({"sample_data": str(sample_data)})
+    genotypes, _ = loc.load_genotypes(zarr=str(out))
+    assert is_dosage_matrix(genotypes)
+    assert genotypes.dtype == np.float32
+    assert loc.positions is not None
+    assert len(loc.positions) == genotypes.shape[0]
+    assert loc.chromosomes is not None
+    assert len(loc.chromosomes) == genotypes.shape[0]
+
+
+def test_converter_refuses_overwrite_without_flag(tmp_path, beagle_inputs):
+    beagle, bam_list, _sd, _ids = beagle_inputs
+    out = tmp_path / "store.zarr"
+    beagle_to_zarr(str(beagle), str(bam_list), str(out))
+    # Second write to the same path without overwrite must fail.
+    with pytest.raises(FileExistsError):
+        beagle_to_zarr(str(beagle), str(bam_list), str(out), overwrite=False)
+    # With overwrite it succeeds.
+    beagle_to_zarr(str(beagle), str(bam_list), str(out), overwrite=True)


### PR DESCRIPTION
Second of three PRs for #60 (Option B: convert GL/beagle to zarr once).

## Summary

Parsing a multi-GB beagle on every run is slow, and the GL loader had no
position source for windowed analysis before #61. This PR adds a one-time
`beagle_to_zarr` converter and teaches the zarr loader to read the resulting
dosage store, so GL data loads fast and carries `variants/POS` / `variants/CHROM`
through the existing zarr path.

## Changes

- **`scripts/beagle_to_zarr.py`** (new, + `beagle_to_zarr` CLI entry) - reads a
  `beagle.gz` + `bam_list`, computes expected dosage with the **same** impute /
  filter pipeline as `_load_from_gl`, parses markers into `variants/POS` /
  `variants/CHROM`, and writes a zarr store with a `dosage` array chunked along
  the sites axis (plus `samples` and a `locator_format="dosage"` attr).
- **`_load_from_zarr`** - a leading continuous-dosage branch detects the
  `dosage` layout and returns the 2D float32 matrix with `self.positions` /
  `self.chromosomes` set. Existing `call_genotype` / `calldata/GT` branches are
  unchanged, so `load_genotypes(zarr=...)` now yields a dosage matrix for a
  dosage store and an `allel.GenotypeArray` for a hard-call store.
- **`pyproject.toml`** - register the `beagle_to_zarr` script; add pytest
  `pythonpath = ["."]` so tests can import the `scripts` package (not part of
  the installed wheel).

Once loaded, positions are set, so windowed analysis works through the PR1
(#61) dosage path with no extra wiring.

## Test plan

- [x] Converter writes the expected layout (dosage float32 chunked on sites, `variants/POS` int, `variants/CHROM`, `samples`).
- [x] Converter dosage is byte-identical to `load_genotypes(gl=..., gl_mode="dosage")`.
- [x] `load_genotypes(zarr=<dosage store>)` returns a 2D float matrix (`is_dosage_matrix`) with positions/chromosomes set.
- [x] `--overwrite` semantics (`FileExistsError` without the flag).
- [x] Regression: hard-call zarr loading (`test_core` zarr test) still passes.
- [x] `ruff check` + `ruff format --check` clean.

## Follow-up (rest of #60)

- PR3: `parallel_windows_leave_one_out` (full LOO per window). #60 closes with PR3.