### PR TITLE
feat(gl): add parallel_windows_leave_one_out (full LOO per window)

### DIFF
--- a/locator/parallel/__init__.py
+++ b/locator/parallel/__init__.py
@@ -6,7 +6,10 @@ try:
     from .ensemble import parallel_train_ensemble
     from .holdout import parallel_holdouts
     from .kfold import parallel_k_fold_holdouts, parallel_leave_one_out
-    from .windowed import parallel_windows_holdouts
+    from .windowed import (
+        parallel_windows_holdouts,
+        parallel_windows_leave_one_out,
+    )
 
     __all__ = [
         "parallel_k_fold_holdouts",
@@ -14,6 +17,7 @@ try:
         "parallel_holdouts",
         "parallel_train_ensemble",
         "parallel_windows_holdouts",
+        "parallel_windows_leave_one_out",
     ]
 except ImportError:
     # Ray not installed - likely during docs build
@@ -29,6 +33,7 @@ except ImportError:
     parallel_holdouts = _not_available
     parallel_train_ensemble = _not_available
     parallel_windows_holdouts = _not_available
+    parallel_windows_leave_one_out = _not_available
 
     __all__ = [
         "parallel_k_fold_holdouts",
@@ -36,4 +41,5 @@ except ImportError:
         "parallel_holdouts",
         "parallel_train_ensemble",
         "parallel_windows_holdouts",
+        "parallel_windows_leave_one_out",
     ]

--- a/locator/parallel/_actor.py
+++ b/locator/parallel/_actor.py
@@ -268,6 +268,83 @@ class WindowActor:
         }
 
 
+@ray.remote
+class WindowLOOActor:
+    """Ray actor for full leave-one-out within each genomic window.
+
+    Per window the dosage slice is filtered once, then every sample is held
+    out in turn and predicted by a model trained on the rest. Filtering once
+    and reusing the filtered matrix across folds keeps the SNP set identical
+    for every fold and lets ``train_holdout`` reuse the compiled model between
+    folds (only the weights are re-initialised). LOO is dosage-only, so the
+    full genotype matrix is a 2D float ndarray kept as-is.
+    """
+
+    def __init__(
+        self,
+        gpu_id: int,
+        gpu_fraction: float,
+        data_ref,
+        gpu_mem_mb: int = DEFAULT_GPU_MEM_MB,
+    ):
+        self._tf = _init_actor_runtime(gpu_id, gpu_fraction, gpu_mem_mb)
+        self._data: Dict[str, Any] = data_ref
+        self._locator = _create_worker_locator(self._data, "actor")
+        self._base_out = self._data["config"]["out"]
+        self._genotypes = self._data["genotypes_array"]
+
+    def ready(self) -> bool:
+        return True
+
+    def run_window_loo(
+        self,
+        window_idx: int,
+        window_label: str,
+        window_chromosome,
+        window_start: int,
+        window_stop: int,
+        snp_indices: List[int],
+    ) -> Dict[str, Any]:
+        empty = {
+            "window_idx": window_idx,
+            "window_label": window_label,
+            "window_chromosome": window_chromosome,
+            "window_start": window_start,
+            "window_stop": window_stop,
+            "rows": None,
+            "n_snps": 0,
+        }
+        if len(snp_indices) == 0:
+            return empty
+
+        loc = self._locator
+        # Filter the window's dosage rows once; reuse for every LOO fold.
+        window_dosage = self._genotypes[snp_indices, :]
+        filtered = loc._filter_genotypes(window_dosage)
+        if filtered.shape[0] == 0:
+            return empty
+
+        rows = []
+        for i in self._data["loo_indices"]:
+            loc.config["out"] = f"{self._base_out}_win{window_idx}_fold{i}"
+            loc.train_holdout(
+                genotypes=None,
+                samples=self._data["samples"],
+                holdout_indices=[i],
+                filtered_genotypes=filtered,
+            )
+            preds = loc.predict_holdout(
+                verbose=False,
+                return_df=True,
+                save_preds_to_disk=False,
+                plot_summary=False,
+                plot_map=False,
+            )
+            if preds is not None:
+                rows.extend(preds[["sampleID", "x_pred", "y_pred"]].to_dict("records"))
+        return {**empty, "rows": rows or None, "n_snps": int(filtered.shape[0])}
+
+
 def _spawn(actor_cls, gpu_ids, gpu_fraction, data_ref, gpu_mem_mb):
     """Spawn ``actor_cls`` instances pinned round-robin across ``gpu_ids``.
 
@@ -318,3 +395,10 @@ def make_ensemble_actors(gpu_ids, gpu_fraction, data_ref, gpu_mem_mb=DEFAULT_GPU
 def make_window_actors(gpu_ids, gpu_fraction, data_ref, gpu_mem_mb=DEFAULT_GPU_MEM_MB):
     """Spawn a pool of ``WindowActor`` actors."""
     return _spawn(WindowActor, gpu_ids, gpu_fraction, data_ref, gpu_mem_mb)
+
+
+def make_window_loo_actors(
+    gpu_ids, gpu_fraction, data_ref, gpu_mem_mb=DEFAULT_GPU_MEM_MB
+):
+    """Spawn a pool of ``WindowLOOActor`` actors."""
+    return _spawn(WindowLOOActor, gpu_ids, gpu_fraction, data_ref, gpu_mem_mb)

--- a/locator/parallel/windowed.py
+++ b/locator/parallel/windowed.py
@@ -22,7 +22,7 @@ from ray.util import ActorPool
 
 from locator.data.filters import is_dosage_matrix
 
-from ._actor import DEFAULT_GPU_MEM_MB, make_window_actors
+from ._actor import DEFAULT_GPU_MEM_MB, make_window_actors, make_window_loo_actors
 from ._helpers import (
     _ensure_ray_initialized,
     _precalculate_bandwidth,
@@ -36,6 +36,56 @@ def _windows_chunk_path(locator) -> str:
 
 def _windows_output_path(locator) -> str:
     return f"{locator.config['out']}_windows_holdouts_predlocs.csv"
+
+
+def _windows_loo_chunk_path(locator) -> str:
+    return f"{locator.config['out']}_windows_loo_chunks.csv"
+
+
+def _windows_loo_output_path(locator) -> str:
+    return f"{locator.config['out']}_windows_loo_predlocs.csv"
+
+
+def _build_windows_to_run(windows, done_labels, positions) -> List[Dict[str, Any]]:
+    """Turn generated windows into dispatch dicts, skipping resumed labels."""
+    windows_to_run: List[Dict[str, Any]] = []
+    for wi, win in enumerate(windows):
+        label = win.get("label", f"pos{win['start']}")
+        if label in done_labels:
+            continue
+        snp_indices = (
+            np.where(win["indices"])[0].tolist()
+            if "indices" in win
+            else np.where((positions >= win["start"]) & (positions < win["stop"]))[
+                0
+            ].tolist()
+        )
+        windows_to_run.append(
+            {
+                "window_idx": wi,
+                "window_label": label,
+                "window_chromosome": win.get("chromosome"),
+                "window_start": win["start"],
+                "window_stop": win["stop"],
+                "snp_indices": snp_indices,
+            }
+        )
+    return windows_to_run
+
+
+def _pivot_window_chunks(chunk_path: str) -> Optional[pd.DataFrame]:
+    """Pivot the long per-window checkpoint to wide ``x_<label>``/``y_<label>``."""
+    chunks = pd.read_csv(chunk_path)
+    if chunks.empty:
+        return None
+    wide = chunks.pivot_table(
+        index="sampleID",
+        columns="window_label",
+        values=["x_pred", "y_pred"],
+        aggfunc="first",
+    )
+    wide.columns = [f"{val.replace('_pred', '')}_{label}" for val, label in wide.columns]
+    return wide.reset_index()
 
 
 def _resume_completed_windows(chunk_path: str) -> set[str]:
@@ -238,28 +288,7 @@ def parallel_windows_holdouts(  # noqa: C901
             f"present in {chunk_path}; skipping those."
         )
 
-    windows_to_run: List[Dict[str, Any]] = []
-    for wi, win in enumerate(windows):
-        label = win.get("label", f"pos{win['start']}")
-        if label in done_labels:
-            continue
-        snp_indices = (
-            np.where(win["indices"])[0].tolist()
-            if "indices" in win
-            else np.where(
-                (locator.positions >= win["start"]) & (locator.positions < win["stop"])
-            )[0].tolist()
-        )
-        windows_to_run.append(
-            {
-                "window_idx": wi,
-                "window_label": label,
-                "window_chromosome": win.get("chromosome"),
-                "window_start": win["start"],
-                "window_stop": win["stop"],
-                "snp_indices": snp_indices,
-            }
-        )
+    windows_to_run = _build_windows_to_run(windows, done_labels, locator.positions)
 
     if windows_to_run:
         # Note: windowed analysis must materialize the full genotype array on
@@ -354,22 +383,199 @@ def parallel_windows_holdouts(  # noqa: C901
             print("Warning: No windows produced predictions.")
         return None
 
-    chunks = pd.read_csv(chunk_path)
-    if chunks.empty:
+    wide = _pivot_window_chunks(chunk_path)
+    if wide is None:
         if verbose:
             print("Warning: No windows produced predictions.")
         return None
 
-    wide = chunks.pivot_table(
-        index="sampleID",
-        columns="window_label",
-        values=["x_pred", "y_pred"],
-        aggfunc="first",
-    )
-    wide.columns = [f"{val.replace('_pred', '')}_{label}" for val, label in wide.columns]
-    wide = wide.reset_index()
-
     if save_full_pred_matrix:
         wide.to_csv(_windows_output_path(locator), index=False)
+
+    return wide
+
+
+def parallel_windows_leave_one_out(  # noqa: C901
+    locator,
+    genotypes,
+    samples,
+    window_start: int = 0,
+    window_size: int = int(5e5),
+    window_stop: Optional[int] = None,
+    respect_chromosomes: bool = True,
+    gpu_ids: List[int] = [0, 1],
+    gpu_fraction: float = 1.0,
+    return_df: bool = True,
+    save_full_pred_matrix: bool = True,
+    verbose: bool = True,
+    na_action: Optional[str] = None,
+    resume: bool = True,
+    gpu_mem_mb: int = DEFAULT_GPU_MEM_MB,
+) -> Union[pd.DataFrame, None]:
+    """Full leave-one-out within every genomic window, across a pool of GPUs.
+
+    For each window, every sample with known coordinates is held out in turn
+    and predicted by a model trained on the rest (``W`` windows x ``N`` samples
+    model fits). Requires continuous-dosage (GL) input with positions already
+    populated (``load_genotypes(gl=...)`` or a dosage zarr). Each window is one
+    Ray task; the actor filters that window's dosage once and loops the LOO
+    folds, so every fold sees the same SNP set. Checkpointing is per window
+    (a window's ``N`` rows flush together) to ``{out}_windows_loo_chunks.csv``.
+    """
+    _ensure_ray_initialized()
+
+    if not is_dosage_matrix(genotypes):
+        raise ValueError(
+            "parallel_windows_leave_one_out requires a continuous-dosage matrix "
+            "(GL input via load_genotypes(gl=...) or a dosage zarr); hard-call "
+            "GenotypeArray input is not supported."
+        )
+
+    locator.samples = samples
+    locator.genotypes = genotypes
+
+    na_action, _ = locator._validate_na_action(samples, na_action, "Windows LOO")
+
+    _load_positions(locator, verbose)
+
+    sample_data, locs = locator._resolve_locations(samples)
+    na_mask = np.isnan(locs[:, 0])
+    loo_indices = [int(i) for i in np.where(~na_mask)[0]]
+    if len(loo_indices) < 2:
+        raise ValueError(
+            f"Leave-one-out needs >= 2 samples with known coordinates, got "
+            f"{len(loo_indices)}."
+        )
+
+    if window_stop is None:
+        window_stop = max(locator.positions)
+
+    from locator.data.windows import generate_genomic_windows
+
+    chromosomes = getattr(locator, "chromosomes", None)
+    windows = generate_genomic_windows(
+        positions=locator.positions,
+        chromosomes=chromosomes,
+        window_start=window_start,
+        window_size=window_size,
+        window_stop=window_stop,
+        respect_chromosomes=respect_chromosomes,
+        min_snps_per_window=locator.config.get("min_snps_per_window", 1),
+        verbose=verbose,
+    )
+
+    bw_calculated, bw_original = _precalculate_bandwidth(
+        locator,
+        locs[~na_mask],
+        f"windows_loo_n{len(loo_indices)}",
+        verbose,
+    )
+
+    chunk_path = _windows_loo_chunk_path(locator)
+    done_labels = _resume_completed_windows(chunk_path) if resume else set()
+    if done_labels and verbose:
+        print(
+            f"Resume: {len(done_labels)} / {len(windows)} windows already "
+            f"present in {chunk_path}; skipping those."
+        )
+
+    windows_to_run = _build_windows_to_run(windows, done_labels, locator.positions)
+
+    if verbose:
+        n_fits = len(windows_to_run) * len(loo_indices)
+        print(
+            f"LOO-per-window: {len(windows_to_run)} windows x {len(loo_indices)} "
+            f"samples = {n_fits} model fits."
+        )
+
+    if windows_to_run:
+        data_ref = ray.put(
+            {
+                "genotypes_array": genotypes,
+                "samples": samples,
+                "sample_data": sample_data,
+                "config": locator.config,
+                "loo_indices": loo_indices,
+            }
+        )
+
+        actors = make_window_loo_actors(
+            gpu_ids=gpu_ids,
+            gpu_fraction=gpu_fraction,
+            data_ref=data_ref,
+            gpu_mem_mb=gpu_mem_mb,
+        )
+        if verbose:
+            print(
+                f"Spawned {len(actors)} WindowLOOActor actors across GPUs "
+                f"{gpu_ids}; dispatching {len(windows_to_run)} windows "
+                f"(gpu_fraction={gpu_fraction})."
+            )
+
+        pool = ActorPool(actors)
+        start_time = time.time()
+
+        pbar = None
+        if verbose:
+            try:
+                from tqdm import tqdm
+
+                pbar = tqdm(total=len(windows_to_run), desc="Windows (LOO)")
+            except ImportError:
+                pass
+
+        completed = 0
+        for result in pool.map_unordered(
+            lambda actor, w: actor.run_window_loo.remote(
+                w["window_idx"],
+                w["window_label"],
+                w["window_chromosome"],
+                w["window_start"],
+                w["window_stop"],
+                w["snp_indices"],
+            ),
+            windows_to_run,
+        ):
+            if result["rows"]:
+                _append_window_to_chunks(
+                    chunk_path, result["window_label"], result["rows"]
+                )
+            completed += 1
+            if pbar is not None:
+                pbar.update(1)
+
+        if pbar is not None:
+            pbar.close()
+
+        total_time = time.time() - start_time
+        if verbose:
+            print(
+                f"\nCompleted {completed} windows in {total_time:.1f}s "
+                f"({total_time / max(completed, 1):.1f}s per window)."
+            )
+
+        for actor in actors:
+            ray.kill(actor)
+    elif verbose:
+        print("All windows already complete.")
+
+    _restore_bandwidth(locator, bw_calculated, bw_original)
+
+    if not return_df:
+        return None
+
+    if not os.path.exists(chunk_path):
+        if verbose:
+            print("Warning: No windows produced predictions.")
+        return None
+
+    wide = _pivot_window_chunks(chunk_path)
+    if wide is None:
+        if verbose:
+            print("Warning: No windows produced predictions.")
+        return None
+
+    if save_full_pred_matrix:
+        wide.to_csv(_windows_loo_output_path(locator), index=False)
 
     return wide

--- a/tests/test_parallel_windowed_loo.py
+++ b/tests/test_parallel_windowed_loo.py
@@ -1,0 +1,128 @@
+"""Tests for the full leave-one-out-per-window dispatcher."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from locator import Locator
+
+try:
+    import ray  # noqa: F401
+
+    RAY_AVAILABLE = True
+except ImportError:
+    RAY_AVAILABLE = False
+
+
+def test_parallel_windows_leave_one_out_is_exported():
+    import locator.parallel as lp
+
+    assert "parallel_windows_leave_one_out" in lp.__all__
+    assert hasattr(lp, "parallel_windows_leave_one_out")
+
+
+@pytest.fixture
+def small_dosage_loo(tmp_path):
+    rng = np.random.default_rng(0)
+    n_snps, n_samples = 60, 8
+    dosage = rng.uniform(0.0, 2.0, size=(n_snps, n_samples)).astype(np.float32)
+    samples = np.array([f"s{i}" for i in range(n_samples)], dtype=object)
+    sample_file = tmp_path / "samples.txt"
+    content = "sampleID\tx\ty\n"
+    for i, sid in enumerate(samples):
+        content += f"{sid}\t{float(i)}\t{float(i * 2)}\n"
+    sample_file.write_text(content)
+
+    config = {
+        "out": str(tmp_path / "loo_test"),
+        "sample_data": str(sample_file),
+        "max_epochs": 2,
+        "patience": 1,
+        "batch_size": 4,
+        "width": 16,
+        "nlayers": 2,
+        "keras_verbose": 0,
+        "verbose_splits": False,
+        "holdout_no_intermediate_saves": True,
+        "save_fold_models": False,
+        "min_snps_per_window": 3,
+    }
+    loc = Locator(config)
+    loc.positions = np.arange(1, n_snps + 1) * 1000  # single chromosome
+    return loc, dosage, samples, tmp_path
+
+
+@pytest.mark.skipif(not RAY_AVAILABLE, reason="Ray not installed")
+@pytest.mark.slow
+def test_parallel_windows_leave_one_out_predicts_every_sample_per_window(
+    small_dosage_loo,
+):
+    from locator.parallel import parallel_windows_leave_one_out
+
+    loc, dosage, samples, tmp_path = small_dosage_loo
+    df = parallel_windows_leave_one_out(
+        locator=loc,
+        genotypes=dosage,
+        samples=samples,
+        window_start=0,
+        window_size=20_000,
+        respect_chromosomes=False,
+        gpu_ids=[],
+        gpu_fraction=0.0,
+        return_df=True,
+        save_full_pred_matrix=True,
+        verbose=False,
+    )
+    assert df is not None
+    # Full LOO: every sample appears, in every window column, with no gaps.
+    assert len(df) == 8
+    x_cols = [c for c in df.columns if c.startswith("x_")]
+    y_cols = [c for c in df.columns if c.startswith("y_")]
+    n_windows = len(x_cols)
+    assert n_windows >= 2
+    assert len(y_cols) == n_windows
+    assert not df[x_cols + y_cols].isna().any().any()
+
+    chunk_path = str(tmp_path / "loo_test_windows_loo_chunks.csv")
+    chunks = pd.read_csv(chunk_path)
+    per_window = chunks.groupby("window_label")["sampleID"].nunique()
+    assert (per_window == 8).all()  # every window predicted all 8 samples
+
+    # Resume: a second run adds no fits (all windows already checkpointed).
+    n_rows_before = len(chunks)
+    parallel_windows_leave_one_out(
+        locator=loc,
+        genotypes=dosage,
+        samples=samples,
+        window_start=0,
+        window_size=20_000,
+        respect_chromosomes=False,
+        gpu_ids=[],
+        gpu_fraction=0.0,
+        return_df=False,
+        verbose=False,
+        resume=True,
+    )
+    assert len(pd.read_csv(chunk_path)) == n_rows_before
+
+
+@pytest.mark.skipif(not RAY_AVAILABLE, reason="Ray not installed")
+def test_parallel_windows_leave_one_out_rejects_hardcall(small_dosage_loo):
+    """Hard-call GenotypeArray input is rejected with a clear error."""
+    import allel
+
+    from locator.parallel import parallel_windows_leave_one_out
+
+    loc, _dosage, samples, _tmp = small_dosage_loo
+    hardcall = allel.GenotypeArray(np.zeros((60, len(samples), 2), dtype="i1"))
+    with pytest.raises(ValueError, match="continuous-dosage"):
+        parallel_windows_leave_one_out(
+            locator=loc,
+            genotypes=hardcall,
+            samples=samples,
+            gpu_ids=[],
+            gpu_fraction=0.0,
+            verbose=False,
+        )


### PR DESCRIPTION
Final PR for #60 (full leave-one-out per window). **Closes #60.**

## Summary

Adds the user's target workflow: for an ANGSD GL (dosage) dataset, run windowed
analysis where, in **each genomic window, every individual is held out in turn**
and predicted by a model trained on the other N-1 (`W` windows x `N` samples
model fits). Builds on the dosage windowing + beagle-marker positions (#61) and
the dosage zarr path (#62).

## Design

- **`WindowLOOActor`** (+ `make_window_loo_actors`) - one Ray task per window;
  the actor filters that window's dosage slice **once** and loops the LOO folds,
  calling `train_holdout(holdout_indices=[i], filtered_genotypes=<window>)` per
  sample. Filtering once keeps the SNP set identical across folds and lets
  `train_holdout` reuse the compiled model between folds (only weights reset).
  Per-window task granularity load-balances well since `W >> #GPUs`.
- **`parallel_windows_leave_one_out`** - dosage-only dispatcher mirroring the
  windowed-holdout scaffolding (position loading, `generate_genomic_windows`,
  bandwidth precompute/restore, per-window checkpoint + `resume`), writing to
  its own `{out}_windows_loo_chunks.csv` / `_windows_loo_predlocs.csv` so a
  partial LOO run can't collide with a holdout run. Logs the `W*N` fit count up
  front and rejects hard-call input with a clear error.
- Factored **`_build_windows_to_run`** and **`_pivot_window_chunks`**, now shared
  by both the holdout and LOO dispatchers (DRYs the existing holdout function).
- Exported `parallel_windows_leave_one_out` from `locator.parallel`.

## Usage

```python
from locator import Locator
from locator.parallel import parallel_windows_leave_one_out

loc = Locator({"out": "win", "sample_data": "sample_data.txt"})
g, s = loc.load_genotypes(gl="chr01.beagle.gz", bam_list="bam.filelist", gl_mode="dosage")
parallel_windows_leave_one_out(loc, g, s, window_size=int(5e5), gpu_ids=[1, 2])
```

## Test plan

- [x] Export check (`parallel_windows_leave_one_out` in `locator.parallel.__all__`).
- [x] End-to-end CPU LOO (`gpu_ids=[]`): every (window, sample) is predicted with no gaps; each window's chunk has all N samples; a resume rerun adds no fits.
- [x] Hard-call `GenotypeArray` input rejected with a `continuous-dosage` error.
- [x] Regression: the refactored `parallel_windows_holdouts` CPU smoke tests still pass.
- [x] `ruff check` + `ruff format --check` clean.

## #60 status

PR1 (#61, dosage windowing) and PR2 (#62, beagle->zarr) are merged; this PR
completes the issue.