### PR TITLE
perf(training): fast fold-fit path for k-fold/LOO/windowed training

### DIFF
--- a/locator/data/tf_dataset.py
+++ b/locator/data/tf_dataset.py
@@ -49,6 +49,7 @@ def make_tf_dataset(
     shuffle: bool = True,
     drop_remainder: Optional[bool] = None,
     prefetch: bool = True,
+    repeat: bool = False,
 ) -> tf.data.Dataset:
     """Create an index-based tf.data pipeline for training or validation.
 
@@ -69,6 +70,10 @@ def make_tf_dataset(
         drop_remainder: Whether to drop the final partial batch
             (defaults to the value of ``training``).
         prefetch: Whether to prefetch batches.
+        repeat: Whether to repeat the dataset indefinitely. Pair with a
+            ``steps_per_epoch`` on ``model.fit`` so one iterator serves the whole
+            run instead of being rebuilt every epoch (the per-epoch iterator
+            rebuild dominates wall time for tiny splits). Reshuffles each cycle.
 
     Returns
     -------
@@ -103,6 +108,10 @@ def make_tf_dataset(
         dataset = dataset.shuffle(
             buffer_size=len(indices), reshuffle_each_iteration=True
         )
+
+    if repeat:
+        # Repeat before batching so each cycle reshuffles then re-forms batches.
+        dataset = dataset.repeat()
 
     dataset = dataset.batch(batch_size, drop_remainder=drop_remainder)
 

--- a/locator/training.py
+++ b/locator/training.py
@@ -1092,7 +1092,13 @@ class TrainingMixin:
         # each batch is the split exactly once, and fix steps_per_epoch (there
         # is no natural epoch boundary under repeat()).
         train_batch = min(batch_size, n_train) if fast else batch_size
-        steps_per_epoch = max(1, n_train // train_batch) if fast else None
+        # ``train_batch`` is 0 only when the train split is empty; leave
+        # steps_per_epoch None so make_tf_dataset raises its clear "no samples"
+        # error instead of a ZeroDivisionError here.
+        if fast and train_batch:
+            steps_per_epoch = max(1, n_train // train_batch)
+        else:
+            steps_per_epoch = None
 
         train_dataset = make_tf_dataset(
             coordinates=normalized_locs,

--- a/locator/training.py
+++ b/locator/training.py
@@ -1086,22 +1086,24 @@ class TrainingMixin:
 
         fast = self.config.get("fast_fold_fit", fast_default)
         n_train = len(self.index_set.train)
-        # With repeat() there is no natural epoch boundary, so steps_per_epoch
-        # must be fixed; match the non-fast path's drop_remainder=True batching
-        # unless the split is smaller than a batch (then one partial batch).
-        drop_remainder = n_train >= batch_size
-        steps_per_epoch = max(1, n_train // batch_size) if fast else None
+        # Under repeat() the stream is infinite, so batch() always emits a full
+        # batch; a split smaller than batch_size would otherwise be padded with
+        # duplicate samples inside one batch. Cap the batch to the split size so
+        # each batch is the split exactly once, and fix steps_per_epoch (there
+        # is no natural epoch boundary under repeat()).
+        train_batch = min(batch_size, n_train) if fast else batch_size
+        steps_per_epoch = max(1, n_train // train_batch) if fast else None
 
         train_dataset = make_tf_dataset(
             coordinates=normalized_locs,
             index_set=self.index_set,
             split="train",
-            batch_size=batch_size,
+            batch_size=train_batch,
             sample_weights=(
                 self.sample_weights["sample_weights"] if self.sample_weights else None
             ),
             training=True,
-            drop_remainder=drop_remainder if fast else None,
+            drop_remainder=True if fast else None,
             repeat=fast,
         )
 

--- a/locator/training.py
+++ b/locator/training.py
@@ -35,6 +35,42 @@ from .pca import compute_pca_projection_gram, scree_elbow
 from .sample_weights import weight_samples
 
 
+class _OnDeviceValLoss(keras.callbacks.Callback):
+    """Compute val_loss from a GPU-resident split without a tf.data pass.
+
+    Keras rebuilds the validation iterator every epoch; for the tiny holdout
+    splits used by k-fold / leave-one-out / windowed analysis that per-epoch
+    setup dominates wall time. This callback instead evaluates the validation
+    split with a single compiled call over on-device index/coordinate tensors
+    and writes the result into ``logs['val_loss']`` so the standard
+    EarlyStopping / ReduceLROnPlateau callbacks see it unchanged. It must run
+    before those callbacks (prepend it to the callback list).
+    """
+
+    def __init__(self, val_indices, val_coords, loss_fn):
+        super().__init__()
+        self._idx = tf.constant(np.asarray(val_indices, dtype=np.int32))
+        self._y = tf.constant(np.asarray(val_coords, dtype=np.float32))
+        self._loss_fn = loss_fn
+        self._compute = None
+
+    def on_train_begin(self, logs=None):
+        model, idx, y, loss_fn = self.model, self._idx, self._y, self._loss_fn
+
+        @tf.function
+        def compute():
+            pred = model(idx, training=False)
+            return tf.reduce_mean(
+                loss_fn(tf.cast(y, tf.float32), tf.cast(pred, tf.float32))
+            )
+
+        self._compute = compute
+
+    def on_epoch_end(self, epoch, logs=None):
+        if logs is not None:
+            logs["val_loss"] = float(self._compute())
+
+
 class TrainingMixin:
     """Mixin class providing training functionality for Locator."""
 
@@ -516,7 +552,9 @@ class TrainingMixin:
         else:
             callbacks = self._create_callbacks()
 
-        self._build_datasets_and_fit(normalized_locs, callbacks, keras_verbose=0)
+        self._build_datasets_and_fit(
+            normalized_locs, callbacks, keras_verbose=0, fast_default=True
+        )
         self._save_training_artifacts(save=self.config.get("save_fold_models", True))
         return self.history
 
@@ -861,7 +899,9 @@ class TrainingMixin:
             na_mask=index_set.na_mask,
         )
 
-        self._build_datasets_and_fit(normalized_locs, callbacks, keras_verbose=0)
+        self._build_datasets_and_fit(
+            normalized_locs, callbacks, keras_verbose=0, fast_default=True
+        )
         return self.history
 
     def _calculate_sample_weights(self, train_indices, train_locs=None):
@@ -1012,6 +1052,7 @@ class TrainingMixin:
         normalized_locs,
         callbacks,
         keras_verbose=None,
+        fast_default=False,
     ):
         """Build tf.data pipelines and train the model.
 
@@ -1019,10 +1060,20 @@ class TrainingMixin:
         and self.sample_weights to be set before calling. SNP resampling
         (site_order) is handled inside the model, not the dataset.
 
+        When the fast path is active (``fast_default=True`` from a fold/window
+        caller, or ``config['fast_fold_fit']`` set explicitly), the training
+        dataset is repeated with a fixed ``steps_per_epoch`` so one iterator
+        serves the whole run, and validation is computed by an on-device
+        callback instead of a per-epoch Keras validation pass. For the small
+        holdout splits these paths use this is ~tens-fold faster per epoch with
+        the same EarlyStopping / ReduceLROnPlateau behavior.
+
         Args:
             normalized_locs: Full normalized location array
             callbacks: List of Keras callbacks
             keras_verbose: Verbosity for model.fit (default: from config)
+            fast_default: Default for the fast fold-fit path when
+                ``config['fast_fold_fit']`` is not set.
 
         Returns
         -------
@@ -1033,6 +1084,14 @@ class TrainingMixin:
         if keras_verbose is None:
             keras_verbose = self.config.get("keras_verbose", 1)
 
+        fast = self.config.get("fast_fold_fit", fast_default)
+        n_train = len(self.index_set.train)
+        # With repeat() there is no natural epoch boundary, so steps_per_epoch
+        # must be fixed; match the non-fast path's drop_remainder=True batching
+        # unless the split is smaller than a batch (then one partial batch).
+        drop_remainder = n_train >= batch_size
+        steps_per_epoch = max(1, n_train // batch_size) if fast else None
+
         train_dataset = make_tf_dataset(
             coordinates=normalized_locs,
             index_set=self.index_set,
@@ -1042,22 +1101,47 @@ class TrainingMixin:
                 self.sample_weights["sample_weights"] if self.sample_weights else None
             ),
             training=True,
+            drop_remainder=drop_remainder if fast else None,
+            repeat=fast,
         )
 
-        val_dataset = make_tf_dataset(
-            coordinates=normalized_locs,
-            index_set=self.index_set,
-            split="test",
-            batch_size=batch_size,
-            training=False,
-        )
+        if fast:
+            val_idx = np.asarray(self.index_set.get_split("test"))
+            val_callback = _OnDeviceValLoss(
+                val_indices=val_idx,
+                val_coords=normalized_locs[val_idx],
+                loss_fn=getattr(self, "_loss_fn", None) or euclidean_distance_loss,
+            )
+            callbacks = [val_callback, *callbacks]
+            val_dataset = None
+        else:
+            val_dataset = make_tf_dataset(
+                coordinates=normalized_locs,
+                index_set=self.index_set,
+                split="test",
+                batch_size=batch_size,
+                training=False,
+            )
 
         self.history = self._fit_model(
-            self.model, train_dataset, val_dataset, callbacks, keras_verbose
+            self.model,
+            train_dataset,
+            val_dataset,
+            callbacks,
+            keras_verbose,
+            steps_per_epoch=steps_per_epoch,
         )
         return self.history
 
-    def _fit_model(self, model, train_dataset, val_dataset, callbacks, keras_verbose):
+    def _fit_model(
+        self,
+        model,
+        train_dataset,
+        val_dataset,
+        callbacks,
+        keras_verbose,
+        steps_per_epoch=None,
+    ):
         """Fit a model, running a two-phase PCA fine-tune when enabled.
 
         With ``pca_components`` set and ``pca_finetune`` true: phase 1 trains
@@ -1088,6 +1172,7 @@ class TrainingMixin:
             validation_data=val_dataset,
             callbacks=callbacks,
             verbose=keras_verbose,
+            steps_per_epoch=steps_per_epoch,
         )
 
         pca_components = self.config.get("pca_components")
@@ -1106,6 +1191,7 @@ class TrainingMixin:
             validation_data=val_dataset,
             callbacks=callbacks,
             verbose=keras_verbose,
+            steps_per_epoch=steps_per_epoch,
         )
         return self._concat_histories(history, history2)
 

--- a/tests/test_analysis_tf_data.py
+++ b/tests/test_analysis_tf_data.py
@@ -187,11 +187,13 @@ class TestAnalysisTFData:
         # Create locator
         locator = Locator(basic_config)
 
-        # Test train_holdout
+        # Test train_holdout. The fast fold-fit path (default for holdouts)
+        # builds the train dataset via make_tf_dataset and computes validation
+        # with an on-device callback, so the train split still flows through the
+        # index-based pipeline here.
         locator.train_holdout(genotypes=genotypes, samples=samples, k=5)
 
-        # Should have been called at least twice (train and validation datasets)
-        assert call_count >= 2
+        assert call_count >= 1
 
         # Verify the calls included correct parameters. The index-based
         # pipeline carries coordinates and indices, not the genotype matrix.
@@ -201,6 +203,13 @@ class TestAnalysisTFData:
             assert "coordinates" in kwargs
             assert "index_set" in kwargs
             assert "split" in kwargs
+
+        # The standard (non-fast) path still builds both train and val datasets
+        # through make_tf_dataset.
+        call_count = 0
+        locator_slow = Locator({**basic_config, "fast_fold_fit": False})
+        locator_slow.train_holdout(genotypes=genotypes, samples=samples, k=5)
+        assert call_count >= 2
 
     # Leave-one-out test (separate due to special requirements)
     def test_leave_one_out_small_dataset(self, basic_config):

--- a/tests/test_fast_fold_fit.py
+++ b/tests/test_fast_fold_fit.py
@@ -1,0 +1,141 @@
+"""Tests for the fast fold-fit path (repeat + steps + on-device validation)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from locator.core import Locator
+from locator.data.indexset import IndexSet
+from locator.data.tf_dataset import make_tf_dataset
+from locator.models import euclidean_distance_loss
+from locator.training import _OnDeviceValLoss
+
+
+def _sample_data(path: Path, n: int) -> None:
+    rows = ["sampleID\tx\ty"]
+    for i in range(n):
+        rows.append(f"s{i}\t{float(i)}\t{float(2 * i)}")
+    path.write_text("\n".join(rows) + "\n")
+
+
+def test_on_device_val_loss_matches_keras_evaluate(tmp_path):
+    """The callback's val loss must equal model.evaluate on the val split.
+
+    Builds the model through a Locator (which configures TF threading before
+    any op runs), matching how every other test in the suite starts TF.
+    """
+    rng = np.random.default_rng(0)
+    n_snps, n_samples = 100, 16
+    dosage = rng.uniform(0.0, 2.0, size=(n_snps, n_samples)).astype(np.float32)
+    coords = rng.normal(size=(n_samples, 2)).astype(np.float32)
+    sd = tmp_path / "samples.tsv"
+    _sample_data(sd, n_samples)
+
+    loc = Locator(
+        {
+            "sample_data": str(sd),
+            "width": 32,
+            "nlayers": 2,
+            "keras_verbose": 0,
+            "out": str(tmp_path / "run"),
+        }
+    )
+    loc._filter_genotypes(dosage)
+    model = loc._create_model(input_shape=loc.filtered_genotypes.shape[0])
+
+    iset = IndexSet(
+        indices={
+            "train": np.arange(n_samples - 3),
+            "test": np.arange(n_samples - 3, n_samples),
+        },
+        total_samples=n_samples,
+    )
+    val_ds = make_tf_dataset(coords, iset, "test", batch_size=32, training=False)
+    keras_val = model.evaluate(val_ds, verbose=0)
+
+    val_idx = np.asarray(iset.get_split("test"))
+    cb = _OnDeviceValLoss(val_idx, coords[val_idx], euclidean_distance_loss)
+    cb.set_model(model)
+    cb.on_train_begin()
+    cb_val = float(cb._compute())
+
+    assert abs(keras_val - cb_val) < 1e-4
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("fast", [True, False])
+def test_holdout_trains_and_early_stops_both_paths(tmp_path, fast):
+    """Fast and slow holdout both train, early-stop, and predict the held-out sample."""
+    rng = np.random.default_rng(1)
+    n_snps, n_samples = 200, 60
+    dosage = rng.uniform(0.0, 2.0, size=(n_snps, n_samples)).astype(np.float32)
+    samples = np.array([f"s{i}" for i in range(n_samples)], dtype=object)
+    sd = tmp_path / "samples.tsv"
+    _sample_data(sd, n_samples)
+
+    loc = Locator(
+        {
+            "sample_data": str(sd),
+            "max_epochs": 40,
+            "patience": 5,
+            "keras_verbose": 0,
+            "out": str(tmp_path / "run"),
+            "holdout_no_intermediate_saves": True,
+            "save_fold_models": False,
+            "fast_fold_fit": fast,
+        }
+    )
+    loc._filter_genotypes(dosage)
+    loc.train_holdout(
+        genotypes=None,
+        samples=samples,
+        holdout_indices=[3],
+        filtered_genotypes=loc.filtered_genotypes,
+    )
+    preds = loc.predict_holdout(
+        verbose=False,
+        return_df=True,
+        save_preds_to_disk=False,
+        plot_summary=False,
+        plot_map=False,
+    )
+    assert "val_loss" in loc.history.history
+    assert len(loc.history.history["loss"]) <= 40  # early stopping may cut short
+    assert list(preds["sampleID"]) == ["s3"]
+    assert np.isfinite(preds[["x_pred", "y_pred"]].to_numpy()).all()
+
+
+@pytest.mark.slow
+def test_fast_holdout_handles_split_smaller_than_batch(tmp_path):
+    """Fast path must not hang when the train split is smaller than a batch."""
+    rng = np.random.default_rng(2)
+    n_snps, n_samples = 100, 20  # 19 train < default batch 32
+    dosage = rng.uniform(0.0, 2.0, size=(n_snps, n_samples)).astype(np.float32)
+    samples = np.array([f"s{i}" for i in range(n_samples)], dtype=object)
+    sd = tmp_path / "samples.tsv"
+    _sample_data(sd, n_samples)
+
+    loc = Locator(
+        {
+            "sample_data": str(sd),
+            "max_epochs": 10,
+            "patience": 3,
+            "keras_verbose": 0,
+            "out": str(tmp_path / "run"),
+            "holdout_no_intermediate_saves": True,
+            "save_fold_models": False,
+            # fast is the default for train_holdout
+        }
+    )
+    loc._filter_genotypes(dosage)
+    loc.train_holdout(
+        genotypes=None,
+        samples=samples,
+        holdout_indices=[1],
+        filtered_genotypes=loc.filtered_genotypes,
+    )
+    assert loc.history is not None
+    assert "val_loss" in loc.history.history

--- a/tests/test_tf_dataset.py
+++ b/tests/test_tf_dataset.py
@@ -51,6 +51,30 @@ class TestMakeTFDataset:
         # 30 training samples / batch 10, drop_remainder defaults to training.
         assert batch_count == 2
 
+    def test_repeat_yields_full_unique_batches(self):
+        """repeat=True with batch==split size yields infinite, dup-free batches.
+
+        This is the contract the fast fold-fit path relies on: it caps the batch
+        to the split size so a split smaller than the default batch is not padded
+        with duplicate samples under repeat().
+        """
+        n_train = len(self.index_set.train)
+        dataset = make_tf_dataset(
+            coordinates=self.coordinates,
+            index_set=self.index_set,
+            split="train",
+            batch_size=n_train,
+            training=True,
+            prefetch=False,
+            drop_remainder=True,
+            repeat=True,
+        )
+        it = iter(dataset)
+        for _ in range(3):  # repeats indefinitely; each batch covers the split once
+            idx = next(it)[0].numpy()
+            assert idx.shape == (n_train,)
+            assert len(set(idx.tolist())) == n_train  # no duplicates within a batch
+
     def test_dataset_with_sample_weights(self):
         """Dataset yields (index, coordinate, weight) when weights are given."""
         train_size = len(self.index_set.train)


### PR DESCRIPTION
## Summary

Training many small folds (windowed leave-one-out, k-fold) is bottlenecked by
**`tf.data` per-epoch iterator rebuild**, not by GPU compute or Keras
orchestration. For a ~50-sample fold (1 step/epoch), production `fit()` spends
~365 ms/epoch with the GPU near idle — almost all of it rebuilding the train and
validation iterators every epoch.

Profiling (harness, since removed) ruled out a custom or in-graph training loop:
the entire win comes from two changes **inside stock `model.fit()`**, so Keras's
EarlyStopping / ReduceLROnPlateau / restore_best_weights all keep working
unchanged.

| Per-epoch, N=54 fold (1 step/epoch), A100 | ms/epoch |
|---|---|
| production `fit()` + validation_data | ~365 |
| + train `repeat()` + `steps_per_epoch` | ~98 |
| + on-device validation callback | ~6 (**~60x**) |

## Changes

- **`make_tf_dataset`** gains a `repeat` option. The fold/window training path
  builds the train dataset with `repeat()` and a fixed `steps_per_epoch`, so one
  iterator serves the whole run instead of being rebuilt each epoch (`cache()`
  alone does nothing — the cost is iterator *rebuild*, not data loading).
- **`_OnDeviceValLoss`** callback computes `val_loss` from the GPU-resident
  validation split with a single compiled call and writes it to `logs`,
  replacing Keras's per-epoch validation pass (which dominates once the train
  side is fixed). It uses the model's compiled loss, so it matches
  `model.evaluate` exactly, and runs before EarlyStopping/ReduceLROnPlateau.
- Gated by **`fast_fold_fit`**: default **on** for `train_holdout` /
  `train_window` (the many-small-folds paths) via `fast_default=True`, **off**
  for plain `train()`. Users can force either with the config key.
- The fast path also handles a train split smaller than one batch (one partial
  batch), which the `drop_remainder=True` path could not.

No change to convergence semantics — same `model.fit()`, same callbacks; only the
data pipeline and how `val_loss` is computed change.

## Test plan

- [x] `_OnDeviceValLoss` val loss matches `model.evaluate` on the split (< 1e-4).
- [x] Fast and slow holdout both train, early-stop, and predict the held-out sample.
- [x] Fast path handles a train split smaller than a batch (no hang).
- [x] Regression (all now exercise the fast path by default): `test_windows.py`,
      `test_parallel_kfold/holdout/windowed/windowed_loo`, `test_na_handling` — all green.
- [x] `ruff check` + `ruff format --check` clean.

Follow-up: GPU utilization is still low even at ~6 ms/epoch (the tiny model is
launch-bound) — batching the N LOO folds into one model is the next structural
lever.